### PR TITLE
Invertible functions

### DIFF
--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -228,6 +228,7 @@ src/Narcissus/Automation/NormalizeFormats.v
 src/Narcissus/Automation/Solver.v
 src/Narcissus/Automation/Solver_8_5.v
 src/Narcissus/Automation/SynthesizeDecoder.v
+src/Narcissus/Automation/Invertible.v
 src/Narcissus/BinLib/AlignWord.v
 src/Narcissus/BinLib/AlignedByteBuffer.v
 src/Narcissus/BinLib/AlignedByteString.v

--- a/src/Narcissus/Automation/ExtractData.v
+++ b/src/Narcissus/Automation/ExtractData.v
@@ -31,7 +31,8 @@ Require Import
         Fiat.Narcissus.Formats.SumTypeOpt
         Fiat.Narcissus.Formats.StringOpt
         Fiat.Narcissus.Automation.Decision
-        Fiat.Narcissus.Automation.Common.
+        Fiat.Narcissus.Automation.Common
+        Fiat.Narcissus.Automation.Invertible.
 
 Lemma decompose_pair_eq {A B}
   : forall (ab ab' : A * B),
@@ -140,6 +141,9 @@ Ltac build_fully_determined_type :=
   (* any product types that might have been built up *)
   (* along the way *)
   subst_projections;
+  (* Also invert all invertible functions / relations to recover the
+  parsed element*)
+  subst_invertible;
   (* And unify with original object *) reflexivity.
 
 Ltac ExtractSource :=

--- a/src/Narcissus/Automation/Invertible.v
+++ b/src/Narcissus/Automation/Invertible.v
@@ -1,4 +1,9 @@
-(*+ Invertable functions *)
+(* Invertible Functions/Releations: When the format uses composition to
+intorudce porjections (in the general sense), we use the invertibility
+of the function/relation to recover the encoded object.  *)
+
+(** * Invertable functions *)
+
 (*Note: this is a special case of Invertible relations bellow. We
 separate for modularity and easier automation/debugging.*)
 
@@ -18,20 +23,19 @@ Proof. intros * ? *  ? HH. rewrite <- HH.
 
 (* | For any equation in the hypothesis that uses an invertible function in the left hand side, it moves the function to the right hand side (and solves the secondary generated subgoals) *)
 Ltac subst_invertible_functions:=
-  simpl in *;
-  repeat match goal with
-         | [ H: ?f ?x = _ |- _ ] =>
-             eapply (CInv_equation _ _ f) in H;
-             (*Solve the subgoals of inversion*)
-             [  |
-               (*Find the right typeclass *) now typeclasses eauto  |
-               (* Solve the predicate *) now simpl in *; eauto
-             ];
-             try subst x
-         end.
+  match goal with
+  | [ H: ?f ?x = _ |- _ ] =>
+      eapply (CInv_equation _ _ f) in H;
+      (*Solve the subgoals of inversion*)
+      [  |
+        (*Find the right typeclass *) now typeclasses eauto  |
+        (* Solve the predicate *) now simpl in *; eauto
+      ];
+      try subst x
+  end.
 
 
-(*+ Invertable relations *)
+(** * Invertable relations *)
 
 (* | Type class defining invertible relations. The predicate can send an element in the domain to many elements in the image. Elements in the codomain have at most one element in the preimage. It accepts a
   predicate P for partially-invertible relations (e.g. nat -> word
@@ -41,16 +45,15 @@ Class ConditionallyInvertibleRel {A B : Type} (F: A -> B -> Prop)(P : A -> Prop)
 
 (* | For any equation in the hypothesis that uses an invertible function in the left hand side, it moves the function to the right hand side (and solves the secondary generated subgoals) *)
 Ltac subst_invertible_relations:=
-  simpl in *;
-  repeat match goal with
-         | [ H: ?f ?x ?y |- _ ] =>
-             eapply CInvRoundTripRel in H;
-             (*Solve the subgoals of inversion*)
-             [  |
-               (*Find the right typeclass *) now typeclasses eauto  |
-               (* Solve the predicate *) now simpl in *; eauto
-             ];
-             try subst x
-         end.
+  match goal with
+  | [ H: ?f ?x ?y |- _ ] =>
+      eapply CInvRoundTripRel in H;
+      (*Solve the subgoals of inversion*)
+      [  |
+        (*Find the right typeclass *) now typeclasses eauto  |
+        (* Solve the predicate *) now simpl in *; eauto
+      ];
+      try subst x
+  end.
 
 Ltac subst_invertible:= simpl in *; repeat first [subst_invertible_functions | subst_invertible_relations]. 

--- a/src/Narcissus/Automation/Invertible.v
+++ b/src/Narcissus/Automation/Invertible.v
@@ -1,0 +1,56 @@
+(*+ Invertable functions *)
+(*Note: this is a special case of Invertible relations bellow. We
+separate for modularity and easier automation/debugging.*)
+
+(* | Type class defining invertible functions. It accepts a
+  predicate P for partially-invertible functions (e.g. nat -> word
+  ) *)
+Class ConditionallyInvertible {A B : Type} (F: A -> B)(P : A -> Prop) (F': B -> A) :=
+  { CInvRoundTrip : forall a, P a -> F' (F a) = a }.
+
+(* This lemma restates the invertible condition as a manipulation of
+  equations.   *)
+Lemma CInv_equation :
+  forall A B F P F' {CInv: @ConditionallyInvertible A B F P F'},
+  forall a b, P a -> F a = b -> a = F' b.
+Proof. intros * ? *  ? HH. rewrite <- HH.
+       rewrite CInvRoundTrip; auto. Qed.
+
+(* | For any equation in the hypothesis that uses an invertible function in the left hand side, it moves the function to the right hand side (and solves the secondary generated subgoals) *)
+Ltac subst_invertible_functions:=
+  simpl in *;
+  repeat match goal with
+         | [ H: ?f ?x = _ |- _ ] =>
+             eapply (CInv_equation _ _ f) in H;
+             (*Solve the subgoals of inversion*)
+             [  |
+               (*Find the right typeclass *) now typeclasses eauto  |
+               (* Solve the predicate *) now simpl in *; eauto
+             ];
+             try subst x
+         end.
+
+
+(*+ Invertable relations *)
+
+(* | Type class defining invertible relations. The predicate can send an element in the domain to many elements in the image. Elements in the codomain have at most one element in the preimage. It accepts a
+  predicate P for partially-invertible relations (e.g. nat -> word
+  ) *)
+Class ConditionallyInvertibleRel {A B : Type} (F: A -> B -> Prop)(P : A -> Prop) (F': B -> A) :=
+  { CInvRoundTripRel : forall a, P a -> forall b, F a b -> a = F' b }.
+
+(* | For any equation in the hypothesis that uses an invertible function in the left hand side, it moves the function to the right hand side (and solves the secondary generated subgoals) *)
+Ltac subst_invertible_relations:=
+  simpl in *;
+  repeat match goal with
+         | [ H: ?f ?x ?y |- _ ] =>
+             eapply CInvRoundTripRel in H;
+             (*Solve the subgoals of inversion*)
+             [  |
+               (*Find the right typeclass *) now typeclasses eauto  |
+               (* Solve the predicate *) now simpl in *; eauto
+             ];
+             try subst x
+         end.
+
+Ltac subst_invertible:= simpl in *; repeat first [subst_invertible_functions | subst_invertible_relations]. 

--- a/src/Narcissus/Examples/Invertible.v
+++ b/src/Narcissus/Examples/Invertible.v
@@ -4,7 +4,7 @@ general sense), we use the invertibility of the function/relation to
 recover the encoded object.  *)
 
 Require Import Fiat.Narcissus.Examples.TutorialPrelude.
-Require Import Fiat.Narcissus.Formats.Reorder.
+(*Require Import Fiat.Narcissus.Formats.Reorder. *)
 Require Import 
         Coq.Sorting.Permutation.
 Require Import Fiat.Narcissus.Automation.Invertible.
@@ -107,6 +107,7 @@ Module FinT.
     apply (@Fin.of_nat_lt (min (wordToNat w) n) (S n)).
     lia.
   Defined.
+  Definition fin2Word {n:nat} (sz:nat) (idx: Fin.t n): word sz := Word.natToWord sz (FinFun.Fin2Restrict.f2n idx). 
   
   Instance CInv_finToWord (n sz:nat):
     ConditionallyInvertible (@fin2Word (S n) sz) (fun a => Fin2Restrict.f2n a < pow2 sz) (@word2Fin n sz).

--- a/src/Narcissus/Examples/Invertible.v
+++ b/src/Narcissus/Examples/Invertible.v
@@ -1,0 +1,221 @@
+(*+ Examples of invertible functions/relations *)
+(* When the format uses composition to intorudce porjections (in the
+general sense), we use the invertibility of the function/relation to
+recover the encoded object.  *)
+
+Require Import Fiat.Narcissus.Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Formats.Reorder.
+Require Import 
+        Coq.Sorting.Permutation.
+Require Import Fiat.Narcissus.Automation.Invertible.
+
+(*For finite types *)
+Require Import Coq.Logic.FinFun.
+
+Set Warnings "-local-declaration".
+Set Nested Proofs Allowed.
+
+
+Module Revert.
+  (* revert words is it's own invers. *)
+  
+  
+Fixpoint wreverse {sz} (w : word sz) : word sz :=
+  match w with
+  | WO          => WO
+  | WS b n rest => append_bit b (wreverse rest)
+  end.
+
+
+(* Prove the inversion lemmas and create an instance of the inversible class *)
+Lemma wreverse_lemma1
+: forall {sz} (b : bool) (w : word sz),
+  wreverse (append_bit b w) = WS b (wreverse w).
+Proof.
+  induction w.
+  simpl. reflexivity.
+  simpl. rewrite IHw. simpl. reflexivity.
+Qed.
+
+Theorem inverse_wreverse
+: forall sz (s v : word sz),
+  wreverse s = v  ->  s = wreverse v.
+Proof.
+  intros. rewrite <- H. clear H v.
+  induction s.
+  simpl. reflexivity. 
+  simpl. rewrite wreverse_lemma1. rewrite <- IHs. reflexivity.
+Qed.
+Instance CInv_wreverse (sz:nat):
+  ConditionallyInvertible (@wreverse sz) (constant True) wreverse .
+Proof.
+  constructor; intros.
+  rewrite <- (inverse_wreverse _ a); reflexivity.
+Qed.
+Opaque wreverse.
+
+
+Record sensor_msg := { firstW: word 8; secondW: word 16 }.
+
+Let format_int_reverse : FormatM sensor_msg ByteString :=
+     format_word ◦ wreverse (sz:=8) ◦ firstW
+  ++ format_word ◦ wreverse (sz:=16) ◦ secondW.
+ 
+Let enc_dec_automatic:
+  EncoderDecoderPair format_int_reverse (constant True).
+Proof. derive_encoder_decoder_pair. Defined.
+
+End Revert.
+
+ 
+
+
+Module Nat.
+  (* Elements using coq nats. The function natToWord is ony invertible
+  as long as the number is bownded. *)
+
+  Instance CInv_natToWord (n:nat): ConditionallyInvertible (natToWord n) (fun x => x < pow2 n) (@wordToNat n).
+  Proof. constructor; intros. apply wordToNat_natToWord_idempotent.
+         apply Nomega.Nlt_in. rewrite Nnat.Nat2N.id, Npow2_nat.
+         assumption.
+  Qed.
+
+
+  (* project from nat *)
+  Record sensor_msg :=
+    { stationID: nat; data: word 16 }.
+
+  Let format :=
+        format_word ◦ natToWord 8 ∘ stationID
+                    ++ format_word ◦ data.
+
+  Let invariant (msg:sensor_msg):= stationID msg < pow2 8.
+  Let enc_dec_nat : EncoderDecoderPair format invariant.
+  Proof. derive_encoder_decoder_pair.  Defined.
+
+  Let encode := encoder_impl enc_dec_nat.
+  Let decode := decoder_impl enc_dec_nat.
+
+End Nat.
+
+Module FinT.
+  (* Elements using finite types `Fin.t`. Works just like for `nat`,
+  but with a little more type dependance. *)
+
+  (*We define the inverse and two possible inversion classes*)
+
+  Definition word2Fin {n sz:nat} (w: word sz): Fin.t (S n).
+  Proof.
+    apply (@Fin.of_nat_lt (min (wordToNat w) n) (S n)).
+    lia.
+  Defined.
+  
+  Instance CInv_finToWord (n sz:nat):
+    ConditionallyInvertible (@fin2Word (S n) sz) (fun a => Fin2Restrict.f2n a < pow2 sz) (@word2Fin n sz).
+  Proof. constructor; intros.
+         unfold word2Fin, fin2Word.
+         match goal with
+           |- @Fin2Restrict.n2f ?a ?b ?c = _ =>
+             (*forget c: TODO: make tactic*)
+             remember c as X eqn:HH; clear HH
+         end.
+         revert X; rewrite wordToNat_natToWord_idempotent.
+         - intros.
+           apply Fin2Restrict.f2n_inj.
+           rewrite Fin2Restrict.f2n_n2f.
+           rewrite min_l; auto.
+           pose proof (Fin2Restrict.f2n_ok a). lia.
+         - eapply Nomega.Nlt_in.
+           rewrite Npow2_nat,Nnat.Nat2N.id.
+           assumption.
+  Qed.
+    
+  Instance CInv_finToWord' (n sz:nat):
+    ConditionallyInvertible (@fin2Word (S n) sz) (fun a => (S n) < pow2 sz) (@word2Fin n sz).
+  Proof. constructor; intros.
+         unfold word2Fin, fin2Word.
+         match goal with
+           |- @Fin2Restrict.n2f ?a ?b ?c = _ =>
+             (*forget c: TODO: make tactic*)
+             remember c as X eqn:HH; clear HH
+         end.
+         revert X; rewrite wordToNat_natToWord_idempotent.
+         - intros.
+           apply Fin2Restrict.f2n_inj.
+           rewrite Fin2Restrict.f2n_n2f.
+           rewrite min_l; auto.
+           pose proof (Fin2Restrict.f2n_ok a). lia.
+         - eapply Nomega.Nlt_in.
+           rewrite Npow2_nat,Nnat.Nat2N.id.
+           etransitivity. eapply Fin2Restrict.f2n_ok.
+           assumption.
+  Qed.
+
+  
+  Record sensor_msg :=
+    { stationID: Fin.t 16; data: word 16 }.
+  
+  Let format :=
+        format_word ◦ (fin2Word 8 ∘ stationID) ++ format_word ◦ data.
+
+  Let invariant (msg:sensor_msg):= Fin2Restrict.f2n (stationID msg) < pow2 8.
+  
+  
+  Let enc_dec : EncoderDecoderPair format invariant.
+  Proof. derive_encoder_decoder_pair. Defined.
+
+  (* In this case the bownd comes from the size of the `Fin.t`. The
+  invariant is trivial (and could be removed in an extra step). *)
+  Let enc_dec'' : EncoderDecoderPair format (fun _ => 16 < pow2 8).
+  Proof. derive_encoder_decoder_pair. Defined.
+
+End FinT.
+
+Module Split.
+  Import Revert.
+  Opaque wreverse.
+  
+  (* `split1`, `split2` don't seem to have inverses. They don't even
+  map the entire input! But with a the help of the predicated P we
+  can encode the other part of the input and make it "invertible". *)
+  
+  Instance CInv_split1 (sz1 sz2: nat) w1:
+    ConditionallyInvertible (split2 sz1 sz2) (fun w => split1 sz1 sz2 w = w1) (@Word.combine sz1 w1 sz2).
+  Proof.
+    constructor; intros.
+    rewrite <- H.
+    apply Word.combine_split.
+  Qed.
+
+
+Let format_int16 : FormatM (word 16) ByteString :=
+     format_word ◦ wreverse (sz:=8) ◦ split1 8 8
+  ++ format_word ◦ wreverse (sz:=8) ◦ split2 8 8.
+
+Let enc_dec_automatic:
+  EncoderDecoderPair format_int16 (constant True).
+  Proof. derive_encoder_decoder_pair. Defined.
+
+
+
+(*Then we can combine multiple applications of split *)
+  Let format_int24 : FormatM (word 24) ByteString :=
+     format_word ◦ wreverse (sz:=8) ◦ split1 8 16
+  ++ format_word ◦ wreverse (sz:=8) ◦ split1 8 8 ◦ split2 8 16
+  ++ format_word ◦ wreverse (sz:=8) ◦ split2 8 8 ◦ split2 8 16.
+
+  Let enc_dec_automatic24: EncoderDecoderPair format_int24 (constant True).
+  Proof. derive_encoder_decoder_pair. Defined.
+
+  
+Let format_int32 : FormatM (word 32) ByteString :=
+     format_word ◦ wreverse (sz:=8) ◦ split1 8 8 ◦ split1 16 16
+  ++ format_word ◦ wreverse (sz:=8) ◦ split2 8 8 ◦ split1 16 16
+  ++ format_word ◦ wreverse (sz:=8) ◦ split1 8 8 ◦ split2 16 16
+  ++ format_word ◦ wreverse (sz:=8) ◦ split2 8 8 ◦ split2 16 16.
+
+Let enc_dec_automatic32:
+  EncoderDecoderPair format_int32 (constant True).
+  Proof. derive_encoder_decoder_pair. Defined.
+  
+End Split.

--- a/src/Narcissus/Examples/Invertible.v
+++ b/src/Narcissus/Examples/Invertible.v
@@ -32,11 +32,9 @@ Lemma wreverse_lemma1
 : forall {sz} (b : bool) (w : word sz),
   wreverse (append_bit b w) = WS b (wreverse w).
 Proof.
-  induction w.
-  simpl. reflexivity.
+  induction w. simpl. reflexivity.
   simpl. rewrite IHw. simpl. reflexivity.
 Qed.
-
 Theorem inverse_wreverse
 : forall sz (s v : word sz),
   wreverse s = v  ->  s = wreverse v.
@@ -46,8 +44,8 @@ Proof.
   simpl. reflexivity. 
   simpl. rewrite wreverse_lemma1. rewrite <- IHs. reflexivity.
 Qed.
-Instance CInv_wreverse (sz:nat):
-  ConditionallyInvertible (@wreverse sz) (constant True) wreverse .
+
+Instance CInv_wreverse (sz:nat): ConditionallyInvertible (@wreverse sz) (constant True) wreverse .
 Proof.
   constructor; intros.
   rewrite <- (inverse_wreverse _ a); reflexivity.


### PR DESCRIPTION
Narcissus currently only supports a narrow set of projection (using '◦'). Specifically, the automation only knows how to reconstruct an encoded object when the projections are exactly record projections or tuples projections (i.e. `fst` and `snd`).

For example, the following format is not currently supported by Narcissus' automation, because it wouldn't know how to recover the original word from their reverted "projection".

```
Record sensor_msg := { firstW: word 8; secondW: word 16 }.

Let format_int_reverse : FormatM sensor_msg ByteString :=
     format_word ◦ wreverse (sz:=8) ◦ firstW
  ++ format_word ◦ wreverse (sz:=16) ◦ secondW.
```

This pull request adds automation to support more general projections (such as `wreverse` or converting `nat` into `word`), as long as they are partially invertible. To do so, it adds a type class `ConditionallyInvertible` that defines invertible projections (up to a conditional predicate for partially invertible projections). The automation will use typeclass automation to search for the right inverse projection to reconstruct the encoded object.

In the example above, `wreverse` is its own inverse so we can define the instance (with a trivial conditional predicate, because `wreverse` is always invertible)

```
Instance CInv_wreverse (sz:nat): ConditionallyInvertible (@wreverse sz) (constant True) wreverse .
```
Then the automation can handle the format `format_int_reverse`.


We also include examples in `Examples/Invertible.v` to showcase some of the use cases and test the automation.

The pull request also includes a stub for invertible relations. The proposed automation (in `ExtractView`) is good enough to reconstruct encoded objects under formats with invertible relations (using composition `Compose_Format`). However composition is not fully supported because it's not yet included in the rules to synthesize the encoder/decoder. I shall include those changes in a separate pull request. 