### PR TITLE
First Pass at Decoder Error Reporting

### DIFF
--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -223,6 +223,7 @@ src/Narcissus/Automation/AlignedAutomation.v
 src/Narcissus/Automation/CacheEncoders.v
 src/Narcissus/Automation/Common.v
 src/Narcissus/Automation/Decision.v
+src/Narcissus/Automation/Error.v
 src/Narcissus/Automation/ExtractData.v
 src/Narcissus/Automation/NormalizeFormats.v
 src/Narcissus/Automation/Solver.v

--- a/src/Narcissus/Automation/AlignedAutomation.v
+++ b/src/Narcissus/Automation/AlignedAutomation.v
@@ -181,6 +181,14 @@ Ltac synthesize_aligned_decoder :=
 
 Ltac maybe_synthesize_aligned_decoder := maybe ltac:(fun _ => timeout 30 synthesize_aligned_decoder) "Unable to synthesize decoder."%string.
 
+Definition extractDecoder {S inv fmt}
+           (d : Maybe (CorrectAlignedDecoderFor (S := S) inv fmt))
+  : MaybeT (forall sz : nat, AlignedDecodeM S sz) d :=
+  match d with
+  | Failure s => s
+  | Success a => projT1 a
+  end.
+
 Lemma length_encode_word' sz :
   forall (w : word sz) (b : ByteString),
     bin_measure (encode_word' _ w b) = sz + bin_measure b.

--- a/src/Narcissus/Automation/AlignedAutomation.v
+++ b/src/Narcissus/Automation/AlignedAutomation.v
@@ -1,6 +1,8 @@
 Require Export Fiat.Common.Coq__8_4__8_5__Compat.
 Require Import
+        Coq.Strings.String
         Coq.ZArith.ZArith
+        Fiat.Narcissus.Automation.Error
         Fiat.Narcissus.BinLib
         Fiat.Narcissus.Common.Specs
         Fiat.Narcissus.Common.ComposeOpt
@@ -15,7 +17,7 @@ Require Import
 Require Import Bedrock.Word.
 
 Ltac start_synthesizing_decoder :=
-  match goal with
+  lazymatch goal with
   | |- CorrectAlignedDecoderFor ?Invariant ?Spec =>
     try unfold Spec (*; try unfold Invariant *)
   end;
@@ -176,6 +178,8 @@ Ltac synthesize_aligned_decoder :=
     continue_on_fail_1
     continue_on_fail
 .
+
+Ltac maybe_synthesize_aligned_decoder := maybe ltac:(fun _ => timeout 30 synthesize_aligned_decoder) "Unable to synthesize decoder."%string.
 
 Lemma length_encode_word' sz :
   forall (w : word sz) (b : ByteString),

--- a/src/Narcissus/Automation/Error.v
+++ b/src/Narcissus/Automation/Error.v
@@ -4,7 +4,7 @@ Require Import
 
 Inductive Maybe (A : Type) :=
 | Failure (s : string)
-| Success (p : Type).
+| Success (a : Type).
 
 Arguments Failure {A} _.
 Arguments Success {A} _.
@@ -20,10 +20,11 @@ Ltac no_error :=
 Ltac throw s :=
   match goal with
     H := ErrorMessage ?s' |- _ => first [ is_evar s'; unify s s'
-                                      | idtac ] (* TODO: Something better when there is already an error? *)
+                                      (* TODO: Something better when there is already an error? *)
+                                      | idtac ]
   end.
 
-Axiom failing_case : forall (A: Type), A.
+Axiom failing_case : forall (e: ErrorReport) (A: Type), A.
 
 Ltac maybe tac errorMsg :=
   match goal with
@@ -33,12 +34,23 @@ Ltac maybe tac errorMsg :=
   lazymatch goal with
   | |- Maybe ?A =>
       let H := fresh in
-      assert A as H by (ltac:(tac ());
+      assert A as H by (unshelve ltac:(tac ());
                        (* If we make it here, the tactic failed to discharge all goals. *)
-                       throw errorMsg; apply failing_case) ;
+                       throw errorMsg; apply failing_case; exact (ErrorMessage errorMsg)) ;
       first [ no_error; exact (Success H)
             | match goal with
                 M := ErrorMessage ?s' |- _ => exact (Failure s')
               end ]
   | _ => fail "Expected a goal with type Maybe."
   end.
+
+
+(* Example *)
+
+(* Ltac foo := intros; auto. *)
+(* Ltac bar := ltac:(foo). *)
+
+(* Lemma baz : Maybe (forall n : nat, n = n). *)
+(*   maybe ltac:(fun _ => bar) "error in baz"%string. *)
+(*   Show Proof. *)
+(* Defined. *)

--- a/src/Narcissus/Automation/Error.v
+++ b/src/Narcissus/Automation/Error.v
@@ -4,7 +4,7 @@ Require Import
 
 Inductive Maybe (A : Type) :=
 | Failure (s : string)
-| Success (a : Type).
+| Success (a : A).
 
 Arguments Failure {A} _.
 Arguments Success {A} _.
@@ -43,14 +43,3 @@ Ltac maybe tac errorMsg :=
               end ]
   | _ => fail "Expected a goal with type Maybe."
   end.
-
-
-(* Example *)
-
-(* Ltac foo := intros; auto. *)
-(* Ltac bar := ltac:(foo). *)
-
-(* Lemma baz : Maybe (forall n : nat, n = n). *)
-(*   maybe ltac:(fun _ => bar) "error in baz"%string. *)
-(*   Show Proof. *)
-(* Defined. *)

--- a/src/Narcissus/Automation/Error.v
+++ b/src/Narcissus/Automation/Error.v
@@ -1,0 +1,44 @@
+Require Import
+        Coq.Strings.String
+        Fiat.Narcissus.Automation.Common.
+
+Inductive Maybe (A : Type) :=
+| Failure (s : string)
+| Success (p : Type).
+
+Arguments Failure {A} _.
+Arguments Success {A} _.
+
+Inductive ErrorReport :=
+  ErrorMessage (s : string).
+
+Ltac no_error :=
+  match goal with
+    H := ErrorMessage ?s |- _ => is_evar s; unify s ""%string; clear H
+  end.
+
+Ltac throw s :=
+  match goal with
+    H := ErrorMessage ?s' |- _ => first [ is_evar s'; unify s s'
+                                      | idtac ] (* TODO: Something better when there is already an error? *)
+  end.
+
+Axiom failing_case : forall (A: Type), A.
+
+Ltac maybe tac errorMsg :=
+  match goal with
+  | M := ErrorMessage ?s |- _ => is_evar s
+  | _ => makeEvar string ltac:(fun x => pose (ErrorMessage x))
+  end ;
+  lazymatch goal with
+  | |- Maybe ?A =>
+      let H := fresh in
+      assert A as H by (ltac:(tac ());
+                       (* If we make it here, the tactic failed to discharge all goals. *)
+                       throw errorMsg; apply failing_case) ;
+      first [ no_error; exact (Success H)
+            | match goal with
+                M := ErrorMessage ?s' |- _ => exact (Failure s')
+              end ]
+  | _ => fail "Expected a goal with type Maybe."
+  end.

--- a/src/Narcissus/Automation/Error.v
+++ b/src/Narcissus/Automation/Error.v
@@ -2,6 +2,56 @@ Require Import
         Coq.Strings.String
         Fiat.Narcissus.Automation.Common.
 
+(** * Error Reporting in Narcissus Automation
+
+    We report errors in Narcissus automation using the <<Maybe>> type
+    defined below. When we know automation (e.g., decoder synthesis)
+    might fail, we wrap the top-level type in a <<Maybe>>. For example,
+    synthesizing a <<CorrectAlignedDecoderFor ?invariant ?format>> might
+    fail if the <<format>> is improperly specified, and so we may wish
+    to synthesize the type <<Maybe (CorrectAlignedDecoderFor ...)>>.
+
+    Rather than require every proof term in the synthesis pipeline to
+    be aware of <<Maybe>> and define their types accordingly, we
+    instead take the following approach:
+
+    1. When we prove a <<Maybe>> type (using the <<maybe>> tactic
+       defined below), we first introduce an <<ErrorReport ?message>>,
+       into the proof context, where <<message>> is an un-unified
+       evar.
+    2. At any point in the automation, any tactic may call the
+       <<throw>> tactic defined below to report a failure. This tactic
+       unifies the <<message>> evar with a concrete error message.
+    3. At the end of the <<maybe>> tactic, we check to see that
+       a) <<message>> is still un-unified, and
+       b) all proof obligations have been discharged.
+       If both of these conditions are met, we yield a <<Success>>.
+       Otherwise, we yield a <<Failure>> with the appropriate error
+       message.
+
+    When a failure is detected, we use the <<failing_case>> axiom
+    defined below to provide a proof object of the appropriate type.
+    In this way, the proof automation successfully completes, but with
+    a <<Failure>> instance. (The intuition here is that a <<Failure>>
+    "inhabits" all types.)
+
+    Tracking error messages in the proof context this way might seem
+    like (and arguably is) a bit of a hack, but the approach has the
+    following advantages:
+
+    - Most of the automation code does not need to worry about
+      <<Maybe>>; the <<Maybe>> type does not proliferate across the
+      entire codebase, but rather is confined to the places that care
+      about errors.
+
+    - When a failure occurs, the proof search stops and a complete
+      proof object is still assembled. Instead of, e.g., monitoring
+      the response buffer to determine synthesis status, external
+      processes using Narcissus can pattern match against <<Maybe>>
+      success or failure on the complete proof object during
+      extraction.
+ *)
+
 Inductive Maybe (A : Type) :=
 | Failure (s : string)
 | Success (a : A).
@@ -9,14 +59,28 @@ Inductive Maybe (A : Type) :=
 Arguments Failure {A} _.
 Arguments Success {A} _.
 
+(**
+    The error object type. Currently we just have an error message string,
+    but we could add other error information or types if needed.
+ *)
 Inductive ErrorReport :=
   ErrorMessage (s : string).
 
+(**
+    If there is an un-unified error in the proof context, unifies it with a
+    dummy string and clears it. Fails otherwise. This tactic is used to check the
+    error state at the end of a <<maybe>> tactic application.
+ *)
 Ltac no_error :=
   match goal with
     H := ErrorMessage ?s |- _ => is_evar s; unify s ""%string; clear H
   end.
 
+(**
+   If there is an error object in the context with an un-unified error message,
+   unifies with the given message string. Otherwise, does nothing.
+   This is the tactic most code should use to report a failure.
+ *)
 Ltac throw s :=
   match goal with
     H := ErrorMessage ?s' |- _ => first [ is_evar s'; unify s s'
@@ -24,8 +88,23 @@ Ltac throw s :=
                                       | idtac ]
   end.
 
+(**
+   The axiom we will use to provide "dummy" proof terms in failure cases.
+   Indexed on ErrorReports to formalize the intuition that errors "inhabit"
+   arbitrary types.
+ *)
 Axiom failing_case : forall (e: ErrorReport) (A: Type), A.
 
+(**
+   The core tactic for proving a goal of type <<Maybe>>. Callers should provide
+   <<tac>>, a tactic (wrapped in a dummy function) which attempts to solve the
+   Maybe's contained type, as well as <<errorMsg>>, the error string to report
+   if <<tac>> fails to discharge all proof obligations.
+
+   Note that <<tac>> must be wrapped in a dummy function from (), i.e.,
+   <<fun _ => tactic here>>, because ltac is call-by-value and we want to,
+   for example, delay any pattern matching on the goal.
+ *)
 Ltac maybe tac errorMsg :=
   match goal with
   | M := ErrorMessage ?s |- _ => is_evar s

--- a/src/Narcissus/Automation/SynthesizeDecoder.v
+++ b/src/Narcissus/Automation/SynthesizeDecoder.v
@@ -1,5 +1,6 @@
 Require Import
         Coq.Bool.Bool
+        Coq.Strings.String
         Coq.ZArith.ZArith
         Fiat.Common.DecideableEnsembles
         Fiat.Common.EnumType
@@ -32,6 +33,7 @@ Require Import
         Fiat.Narcissus.Formats.StringOpt
         Fiat.Narcissus.Formats.Delimiter
         Fiat.Narcissus.Formats.Lexeme
+        Fiat.Narcissus.Automation.Error
         Fiat.Narcissus.Automation.NormalizeFormats
         Fiat.Narcissus.Automation.Decision
         Fiat.Narcissus.Automation.Common
@@ -92,39 +94,42 @@ Ltac apply_base_rule :=
   (* Word *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ format_word _ _ _] =>
-    intros; eapply (Word_decode_correct H)
+    intros; eapply (Word_decode_correct H); throw "Could not synthesize decoder for word."%string
 
   (* Natural Numbers *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ (format_nat _) _ _ _] =>
-    intros; revert H; eapply Nat_decode_correct
+    intros; revert H; eapply Nat_decode_correct; throw "Could not synthesize decoder for nat."%string
 
   (* Booleans *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ (format_bool) _ _ _] =>
-    intros; revert H; eapply bool_decode_correct
+    intros; revert H; eapply bool_decode_correct; throw "Could not synthesize decoder for boolean."%string
 
   (* Strings *)
   | H : cache_inv_Property _ _
   |- context[CorrectDecoder _ _ _ _ StringOpt.format_string _ _ _ ] =>
-    eapply (StringOpt.String_decode_correct _ H)
+    eapply (StringOpt.String_decode_correct _ H); throw "Could not synthesize decoder for string."%string
 
   (* Enumerated Types *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _  _ _ _ (format_enum ?tb) _ _ _] =>
     intros;
     eapply (fun NoDup => @Enum_decode_correct _ _ _ _ _ _ _ tb NoDup _ H);
-    solve_side_condition
+    solve_side_condition;
+    throw "Could not synthesize decoder for enum."%string
 
   (* Unused words *)
   | |- context [CorrectDecoder _  _ _ _ (format_unused_word _) _ _ _] =>
-    intros; eapply unused_word_decode_correct; eauto
+    intros; eapply unused_word_decode_correct; eauto;
+    throw "Could not synthesize decoder for unused word."%string
 
   (* ByteBuffers *)
   | H : cache_inv_Property ?mnd _
     |- CorrectDecoder _ _ _ _ format_bytebuffer _ _ _ =>
     intros; eapply @ByteBuffer_decode_correct;
-    first [exact H | solve [intros; intuition eauto] ]
+    first [exact H | solve [intros; intuition eauto] ];
+    throw "Could not synthesize decoder for byte buffer."%string
 
   (* Hook for new base rules. *)
   | |- _ => apply_new_base_rule

--- a/src/Narcissus/Automation/SynthesizeDecoder.v
+++ b/src/Narcissus/Automation/SynthesizeDecoder.v
@@ -94,42 +94,49 @@ Ltac apply_base_rule :=
   (* Word *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ format_word _ _ _] =>
-    intros; eapply (Word_decode_correct H); throw "Could not synthesize decoder for word."%string
+    intros;
+    first [ solve [eapply (Word_decode_correct H)]
+          | throw "Could not synthesize decoder for word."%string ]
 
   (* Natural Numbers *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ (format_nat _) _ _ _] =>
-    intros; revert H; eapply Nat_decode_correct; throw "Could not synthesize decoder for nat."%string
+    intros; revert H;
+    first [ solve [eapply Nat_decode_correct]
+          | throw "Could not synthesize decoder for nat."%string ]
 
   (* Booleans *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _ _ _ _ (format_bool) _ _ _] =>
-    intros; revert H; eapply bool_decode_correct; throw "Could not synthesize decoder for boolean."%string
+    first [ solve [intros; revert H; eapply bool_decode_correct]
+          | throw "Could not synthesize decoder for boolean."%string ]
 
   (* Strings *)
   | H : cache_inv_Property _ _
   |- context[CorrectDecoder _ _ _ _ StringOpt.format_string _ _ _ ] =>
-    eapply (StringOpt.String_decode_correct _ H); throw "Could not synthesize decoder for string."%string
+    first [ solve [eapply (StringOpt.String_decode_correct _ H)]
+          | throw "Could not synthesize decoder for string."%string ]
 
   (* Enumerated Types *)
   | H : cache_inv_Property _ _
     |- context [CorrectDecoder _  _ _ _ (format_enum ?tb) _ _ _] =>
-    intros;
-    eapply (fun NoDup => @Enum_decode_correct _ _ _ _ _ _ _ tb NoDup _ H);
-    solve_side_condition;
-    throw "Could not synthesize decoder for enum."%string
+    intros; eapply (fun NoDup => @Enum_decode_correct _ _ _ _ _ _ _ tb NoDup _ H);
+    first [ solve [solve_side_condition]
+          | throw "Could not synthesize decoder for enum."%string ]
 
   (* Unused words *)
   | |- context [CorrectDecoder _  _ _ _ (format_unused_word _) _ _ _] =>
-    intros; eapply unused_word_decode_correct; eauto;
-    throw "Could not synthesize decoder for unused word."%string
+    intros; eapply unused_word_decode_correct;
+    first [ solve[eauto]
+          | throw "Could not synthesize decoder for unused word."%string ]
 
   (* ByteBuffers *)
   | H : cache_inv_Property ?mnd _
     |- CorrectDecoder _ _ _ _ format_bytebuffer _ _ _ =>
     intros; eapply @ByteBuffer_decode_correct;
-    first [exact H | solve [intros; intuition eauto] ];
-    throw "Could not synthesize decoder for byte buffer."%string
+    first [ exact H
+          | solve [intros; intuition eauto]
+          | throw "Could not synthesize decoder for byte buffer."%string ]
 
   (* Hook for new base rules. *)
   | |- _ => apply_new_base_rule

--- a/src/Narcissus/Examples/Errors/2022-05-27-error-report.txt
+++ b/src/Narcissus/Examples/Errors/2022-05-27-error-report.txt
@@ -1,0 +1,2531 @@
+--------------------------------------------
+-- Narcissus Error Examples Output Report --
+--------------------------------------------
+
+./src/Narcissus/Examples/Errors/General/PointedComposition.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (fun m : msg => format_word (data m))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (FormatM msg ByteString))
+                 (fun m : msg => format_word (data m))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (EquivFormat (fun m : msg => format_word (data m))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (FormatM msg ByteString))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (FormatM msg ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (FormatM msg ByteString)))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/General/WrongCircle.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant (format_word ∘ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant failing_case (ErrorMessage "Unable to synthesize decoder.")
+                 (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                    invariant invariant eq (format_word ∘ data)
+                    (failing_case
+                       (ErrorMessage "Unable to synthesize decoder.")
+                       (DecodeM (msg * ByteString) ByteString))
+                    (failing_case
+                       (ErrorMessage "Unable to synthesize decoder.")
+                       (CacheDecode -> Prop)) (format_word ∘ data)))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (format_nat 7 ◦ const 0 ++ format_bool ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_nat 7 ◦ const 0 ++
+                  format_bool ◦ data ++ empty_Format)
+                 (format_nat 7 ◦ const 0 ++ format_bool ◦ data)
+                 (EquivFormat_UnderSequence' (format_nat 7 ◦ const 0)
+                    (format_nat 7 ◦ const 0) (format_bool ◦ data)
+                    (format_bool ◦ data ++ empty_Format)
+                    (EquivFormat_reflexive (format_nat 7 ◦ const 0))
+                    (EquivFormat_Projection_Format_Empty_Format' format_bool
+                       format_bool data data
+                       (EquivFormat_reflexive (format_bool ◦ data))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_nat 7 ◦ const 0 ++
+                        format_bool ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_nat 7 ◦ const 0 ++
+                        format_bool ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (constant format_nat 7 0 ++ format_bool ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (constant format_nat 7 0 ++
+                  format_bool ◦ data ++ empty_Format)
+                 (constant format_nat 7 0 ++ format_bool ◦ data)
+                 (EquivFormat_UnderSequence' (constant format_nat 7 0)
+                    (constant format_nat 7 0) (format_bool ◦ data)
+                    (format_bool ◦ data ++ empty_Format)
+                    (EquivFormat_reflexive (constant format_nat 7 0))
+                    (EquivFormat_Projection_Format_Empty_Format' format_bool
+                       format_bool data data
+                       (EquivFormat_reflexive (format_bool ◦ data))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (constant format_nat 7 0 ++
+                        format_bool ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (constant format_nat 7 0 ++
+                        format_bool ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v", line 10, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.
+
+./src/Narcissus/Examples/Errors/FormatWord/Endian.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (format_word ◦ split1 8 8 ∘ data ++ format_word ◦ split2 8 8 ∘ data)
+     (sequence_Decode decode_word
+        (constant sequence_Decode decode_word
+                    (failing_case
+                       (ErrorMessage "Unable to synthesize decoder.")
+                       (word 8 -> DecodeM (msg * ByteString) ByteString))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      (fun P0 : CacheDecode -> Prop =>
+       (fun P1 : CacheDecode -> Prop =>
+        forall (b : nat) (cd : CacheDecode), P1 cd -> P1 (addD cd b)) P0 /\
+       failing_case (ErrorMessage "Unable to synthesize decoder.")
+         ((CacheDecode -> Prop) -> Prop) P0) P)
+     (fun
+        H3 : cache_inv_Property
+               (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  (CacheDecode -> Prop))
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                (fun P0 : CacheDecode -> Prop =>
+                 (fun P1 : CacheDecode -> Prop =>
+                  forall (b : nat) (cd : CacheDecode),
+                  P1 cd -> P1 (addD cd b)) P0 /\
+                 failing_case (ErrorMessage "Unable to synthesize decoder.")
+                   ((CacheDecode -> Prop) -> Prop) P0) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode decode_word
+           (constant sequence_Decode decode_word
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (word 8 -> DecodeM (msg * ByteString) ByteString))))
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (CacheDecode -> Prop))
+        (format_word ◦ split1 8 8 ∘ data ++
+         format_word ◦ split2 8 8 ∘ data ++ empty_Format)
+        (format_word ◦ split1 8 8 ∘ data ++ format_word ◦ split2 8 8 ∘ data)
+        (EquivFormat_UnderSequence' (format_word ◦ split1 8 8 ∘ data)
+           (format_word ◦ split1 8 8 ∘ data)
+           (format_word ◦ split2 8 8 ∘ data)
+           (format_word ◦ split2 8 8 ∘ data ++ empty_Format)
+           (EquivFormat_reflexive (format_word ◦ split1 8 8 ∘ data))
+           (EquivFormat_Projection_Format_Empty_Format' format_word
+              format_word (split2 8 8 ∘ data) (split2 8 8 ∘ data)
+              (EquivFormat_reflexive (format_word ◦ split2 8 8 ∘ data))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           (split1 8 8 ∘ data) invariant (constant True) format_word
+           (format_word ◦ split2 8 8 ∘ data ++ empty_Format) decode_word
+           (fun
+              H6 : cache_inv_Property
+                     (failing_case
+                        (ErrorMessage "Unable to synthesize decoder.")
+                        (CacheDecode -> Prop))
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Word_decode_correct H6)
+           (fun s : msg => constant I)
+           (constant sequence_Decode decode_word
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (word 8 -> DecodeM (msg * ByteString) ByteString)))
+           (fun (v1 : word 8)
+              (H6 : cache_inv_Property
+                      (failing_case
+                         (ErrorMessage "Unable to synthesize decoder.")
+                         (CacheDecode -> Prop))
+                      (fun P : CacheDecode -> Prop =>
+                       (fun P0 : CacheDecode -> Prop =>
+                        forall (b : nat) (cd : CacheDecode),
+                        P0 cd -> P0 (addD cd b)) P /\
+                       failing_case
+                         (ErrorMessage "Unable to synthesize decoder.")
+                         ((CacheDecode -> Prop) -> Prop) P)) =>
+            constant (let H8 := true in
+                      let H9 := true in
+                      format_sequence_correct H6
+                        AlignedByteString.ByteStringQueueMonoid
+                        (split2 8 8 ∘ data)
+                        (fun s : msg =>
+                         invariant s /\ IsProj (split1 8 8 ∘ data) v1 s)
+                        (constant True) format_word empty_Format decode_word
+                        (fun
+                           H10 : cache_inv_Property
+                                   (failing_case
+                                      (ErrorMessage
+                                         "Unable to synthesize decoder.")
+                                      (CacheDecode -> Prop))
+                                   (fun P : CacheDecode -> Prop =>
+                                    forall (b : nat) (cd : CacheDecode),
+                                    P cd -> P (addD cd b)) =>
+                         Word_decode_correct H10) 
+                        (fun s : msg => constant I)
+                        (failing_case
+                           (ErrorMessage "Unable to synthesize decoder.")
+                           (word 8 -> DecodeM (msg * ByteString) ByteString))
+                        (fun v0 : word 8 =>
+                         constant (constant failing_case
+                                              (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                              (CorrectDecoder
+                                                 AlignedByteString.ByteStringQueueMonoid
+                                                 (fun s : msg =>
+                                                 (invariant s /\
+                                                 IsProj 
+                                                 (split1 8 8 ∘ data) v1 s) /\
+                                                 IsProj 
+                                                 (split2 8 8 ∘ data) v0 s)
+                                                 (fun s : msg =>
+                                                 (invariant s /\
+                                                 IsProj 
+                                                 (split1 8 8 ∘ data) v1 s) /\
+                                                 IsProj 
+                                                 (split2 8 8 ∘ data) v0 s) eq
+                                                 empty_Format
+                                                 (failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (word 8 ->
+                                                 DecodeM 
+                                                 (msg * ByteString)
+                                                 ByteString) v0)
+                                                 (failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (CacheDecode -> Prop))
+                                                 empty_Format)))))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (fun P : CacheDecode -> Prop =>
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop) P)))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (sequence_Decode decode_word
+           (constant sequence_Decode decode_word
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (word 8 -> DecodeM (msg * ByteString) ByteString)))
+           b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v", line 10, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.
+
+./src/Narcissus/Examples/Errors/FormatString/StringConst.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (format_string ◦ const "<data>" ++
+      format_word ◦ data ++ format_string ◦ const "</data>")
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_string ◦ const "<data>" ++
+                  format_word ◦ data ++
+                  format_string ◦ const "</data>" ++ empty_Format)
+                 (format_string ◦ const "<data>" ++
+                  format_word ◦ data ++ format_string ◦ const "</data>")
+                 (EquivFormat_UnderSequence' (format_string ◦ const "<data>")
+                    (format_string ◦ const "<data>")
+                    (format_word ◦ data ++ format_string ◦ const "</data>")
+                    (format_word ◦ data ++
+                     format_string ◦ const "</data>" ++ empty_Format)
+                    (EquivFormat_reflexive (format_string ◦ const "<data>"))
+                    (EquivFormat_UnderSequence' (format_word ◦ data)
+                       (format_word ◦ data) (format_string ◦ const "</data>")
+                       (format_string ◦ const "</data>" ++ empty_Format)
+                       (EquivFormat_reflexive (format_word ◦ data))
+                       (EquivFormat_Projection_Format_Empty_Format'
+                          format_string format_string 
+                          (const "</data>") (const "</data>")
+                          (EquivFormat_reflexive
+                             (format_string ◦ const "</data>")))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_string ◦ const "<data>" ++
+                        format_word ◦ data ++
+                        format_string ◦ const "</data>" ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_string ◦ const "<data>" ++
+                        format_word ◦ data ++
+                        format_string ◦ const "</data>" ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/Record/NestedRecord.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (format_word ◦ data ++
+      (format_word ◦ age) ◦ who ++ (format_word ◦ salary) ◦ who)
+     (sequence_Decode decode_word
+        (constant sequence_Decode decode_word
+                    (constant sequence_Decode decode_word
+                                (failing_case
+                                   (ErrorMessage
+                                      "Unable to synthesize decoder.")
+                                   (word 8 ->
+                                    DecodeM (msg * ByteString) ByteString)))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      (fun P0 : CacheDecode -> Prop =>
+       (fun P1 : CacheDecode -> Prop =>
+        forall (b : nat) (cd : CacheDecode), P1 cd -> P1 (addD cd b)) P0 /\
+       (fun P1 : CacheDecode -> Prop =>
+        (fun P2 : CacheDecode -> Prop =>
+         forall (b : nat) (cd : CacheDecode), P2 cd -> P2 (addD cd b)) P1 /\
+        failing_case (ErrorMessage "Unable to synthesize decoder.")
+          ((CacheDecode -> Prop) -> Prop) P1) P0) P)
+     (fun
+        H3 : cache_inv_Property
+               (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  (CacheDecode -> Prop))
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                (fun P0 : CacheDecode -> Prop =>
+                 (fun P1 : CacheDecode -> Prop =>
+                  forall (b : nat) (cd : CacheDecode),
+                  P1 cd -> P1 (addD cd b)) P0 /\
+                 (fun P1 : CacheDecode -> Prop =>
+                  (fun P2 : CacheDecode -> Prop =>
+                   forall (b : nat) (cd : CacheDecode),
+                   P2 cd -> P2 (addD cd b)) P1 /\
+                  failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    ((CacheDecode -> Prop) -> Prop) P1) P0) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode decode_word
+           (constant sequence_Decode decode_word
+                       (constant sequence_Decode decode_word
+                                   (failing_case
+                                      (ErrorMessage
+                                         "Unable to synthesize decoder.")
+                                      (word 8 ->
+                                       DecodeM (msg * ByteString) ByteString)))))
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (CacheDecode -> Prop))
+        (format_word ◦ data ++
+         format_word ◦ age ∘ who ++
+         format_word ◦ salary ∘ who ++ empty_Format)
+        (format_word ◦ data ++
+         (format_word ◦ age) ◦ who ++ (format_word ◦ salary) ◦ who)
+        (EquivFormat_UnderSequence' (format_word ◦ data) 
+           (format_word ◦ data)
+           ((format_word ◦ age) ◦ who ++ (format_word ◦ salary) ◦ who)
+           (format_word ◦ age ∘ who ++
+            format_word ◦ salary ∘ who ++ empty_Format)
+           (EquivFormat_reflexive (format_word ◦ data))
+           (EquivFormat_UnderSequence' ((format_word ◦ age) ◦ who)
+              (format_word ◦ age ∘ who) ((format_word ◦ salary) ◦ who)
+              (format_word ◦ salary ∘ who ++ empty_Format)
+              (EquivFormat_trans ((format_word ◦ age) ◦ who)
+                 (format_word ◦ age ∘ who) (format_word ◦ age ∘ who)
+                 (EquivFormat_compose_map format_word who age)
+                 (EquivFormat_reflexive (format_word ◦ age ∘ who)))
+              (EquivFormat_Projection_Format_Empty_Format'
+                 (format_word ◦ salary) format_word who 
+                 (salary ∘ who)
+                 (EquivFormat_compose_map format_word who salary))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           data invariant (constant True) format_word
+           (format_word ◦ age ∘ who ++
+            format_word ◦ salary ∘ who ++ empty_Format) decode_word
+           (fun
+              H6 : cache_inv_Property
+                     (failing_case
+                        (ErrorMessage "Unable to synthesize decoder.")
+                        (CacheDecode -> Prop))
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Word_decode_correct H6)
+           (fun s : msg => constant I)
+           (constant sequence_Decode decode_word
+                       (constant sequence_Decode decode_word
+                                   (failing_case
+                                      (ErrorMessage
+                                         "Unable to synthesize decoder.")
+                                      (word 8 ->
+                                       DecodeM (msg * ByteString) ByteString))))
+           (fun (v1 : word 8)
+              (H6 : cache_inv_Property
+                      (failing_case
+                         (ErrorMessage "Unable to synthesize decoder.")
+                         (CacheDecode -> Prop))
+                      (fun P : CacheDecode -> Prop =>
+                       (fun P0 : CacheDecode -> Prop =>
+                        forall (b : nat) (cd : CacheDecode),
+                        P0 cd -> P0 (addD cd b)) P /\
+                       (fun P0 : CacheDecode -> Prop =>
+                        (fun P1 : CacheDecode -> Prop =>
+                         forall (b : nat) (cd : CacheDecode),
+                         P1 cd -> P1 (addD cd b)) P0 /\
+                        failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          ((CacheDecode -> Prop) -> Prop) P0) P)) =>
+            constant (let H8 := true in
+                      let H9 := true in
+                      format_sequence_correct H6
+                        AlignedByteString.ByteStringQueueMonoid 
+                        (age ∘ who)
+                        (fun s : msg => invariant s /\ IsProj data v1 s)
+                        (constant True) format_word
+                        (format_word ◦ salary ∘ who ++ empty_Format)
+                        decode_word
+                        (fun
+                           H10 : cache_inv_Property
+                                   (failing_case
+                                      (ErrorMessage
+                                         "Unable to synthesize decoder.")
+                                      (CacheDecode -> Prop))
+                                   (fun P : CacheDecode -> Prop =>
+                                    forall (b : nat) (cd : CacheDecode),
+                                    P cd -> P (addD cd b)) =>
+                         Word_decode_correct H10) 
+                        (fun s : msg => constant I)
+                        (constant sequence_Decode decode_word
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (word 8 ->
+                                        DecodeM (msg * ByteString) ByteString)))
+                        (fun (v0 : word 8)
+                           (H10 : cache_inv_Property
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (CacheDecode -> Prop))
+                                    (fun P : CacheDecode -> Prop =>
+                                     (fun P0 : CacheDecode -> Prop =>
+                                      forall (b : nat) (cd : CacheDecode),
+                                      P0 cd -> P0 (addD cd b)) P /\
+                                     failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       ((CacheDecode -> Prop) -> Prop) P)) =>
+                         constant (let H12 := true in
+                                   let H13 := true in
+                                   format_sequence_correct H10
+                                     AlignedByteString.ByteStringQueueMonoid
+                                     (salary ∘ who)
+                                     (fun s : msg =>
+                                      (invariant s /\ IsProj data v1 s) /\
+                                      IsProj (age ∘ who) v0 s)
+                                     (constant True) format_word empty_Format
+                                     decode_word
+                                     (fun
+                                        H14 : cache_inv_Property
+                                                (failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (CacheDecode -> Prop))
+                                                (fun P : CacheDecode -> Prop
+                                                 =>
+                                                 forall 
+                                                 (b : nat) 
+                                                 (cd : CacheDecode),
+                                                 P cd -> P (addD cd b)) =>
+                                      Word_decode_correct H14)
+                                     (fun s : msg => constant I)
+                                     (failing_case
+                                        (ErrorMessage
+                                           "Unable to synthesize decoder.")
+                                        (word 8 ->
+                                         DecodeM (msg * ByteString)
+                                           ByteString))
+                                     (fun v2 : word 8 =>
+                                      constant (constant 
+                                                failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (CorrectDecoder
+                                                 AlignedByteString.ByteStringQueueMonoid
+                                                 (fun s : msg =>
+                                                 ((invariant s /\
+                                                 IsProj data v1 s) /\
+                                                 IsProj (age ∘ who) v0 s) /\
+                                                 IsProj (salary ∘ who) v2 s)
+                                                 (fun s : msg =>
+                                                 ((invariant s /\
+                                                 IsProj data v1 s) /\
+                                                 IsProj (age ∘ who) v0 s) /\
+                                                 IsProj (salary ∘ who) v2 s)
+                                                 eq empty_Format
+                                                 (failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (word 8 ->
+                                                 DecodeM 
+                                                 (msg * ByteString)
+                                                 ByteString) v2)
+                                                 (failing_case
+                                                 (ErrorMessage
+                                                 "Unable to synthesize decoder.")
+                                                 (CacheDecode -> Prop))
+                                                 empty_Format)))))))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (fun P : CacheDecode -> Prop =>
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop) P)))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (sequence_Decode decode_word
+           (constant sequence_Decode decode_word
+                       (constant sequence_Decode decode_word
+                                   (failing_case
+                                      (ErrorMessage
+                                         "Unable to synthesize decoder.")
+                                      (word 8 ->
+                                       DecodeM (msg * ByteString) ByteString))))
+           b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/Record/FieldMissing.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant (format_word ◦ data)
+     (sequence_Decode decode_word
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (word 8 -> DecodeM (msg * ByteString) ByteString)))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop) P)
+     (fun
+        H3 : cache_inv_Property
+               (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  (CacheDecode -> Prop))
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  ((CacheDecode -> Prop) -> Prop) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode decode_word
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (word 8 -> DecodeM (msg * ByteString) ByteString)))
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (CacheDecode -> Prop)) (format_word ◦ data ++ empty_Format)
+        (format_word ◦ data)
+        (EquivFormat_Projection_Format_Empty_Format' format_word format_word
+           data data (EquivFormat_reflexive (format_word ◦ data)))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           data invariant (constant True) format_word empty_Format
+           decode_word
+           (fun
+              H6 : cache_inv_Property
+                     (failing_case
+                        (ErrorMessage "Unable to synthesize decoder.")
+                        (CacheDecode -> Prop))
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Word_decode_correct H6)
+           (fun s : msg => constant I)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (word 8 -> DecodeM (msg * ByteString) ByteString))
+           (fun v1 : word 8 =>
+            constant (constant failing_case
+                                 (ErrorMessage
+                                    "Unable to synthesize decoder.")
+                                 (CorrectDecoder
+                                    AlignedByteString.ByteStringQueueMonoid
+                                    (fun s : msg =>
+                                     invariant s /\ IsProj data v1 s)
+                                    (fun s : msg =>
+                                     invariant s /\ IsProj data v1 s) eq
+                                    empty_Format
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (word 8 ->
+                                        DecodeM (msg * ByteString) ByteString)
+                                       v1)
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (CacheDecode -> Prop)) empty_Format)))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (fun P : CacheDecode -> Prop =>
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop) P)))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (sequence_Decode decode_word
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (word 8 -> DecodeM (msg * ByteString) ByteString)) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list format_word ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_nat 8 ◦ Datatypes.length ∘ data ++
+                  format_list format_word ◦ data ++ empty_Format)
+                 ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+                  format_list format_word ◦ data)
+                 (EquivFormat_UnderSequence'
+                    ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                    (format_nat 8 ◦ Datatypes.length ∘ data)
+                    (format_list format_word ◦ data)
+                    (format_list format_word ◦ data ++ empty_Format)
+                    (EquivFormat_trans
+                       ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (EquivFormat_compose_map (format_nat 8) data
+                          Datatypes.length)
+                       (EquivFormat_reflexive
+                          (format_nat 8 ◦ Datatypes.length ∘ data)))
+                    (EquivFormat_Projection_Format_Empty_Format'
+                       (format_list format_word) (format_list format_word)
+                       data data
+                       (EquivFormat_reflexive
+                          (format_list format_word ◦ data))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list format_word ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list format_word ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list (format_nat 8) ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_nat 8 ◦ Datatypes.length ∘ data ++
+                  format_list (format_nat 8) ◦ data ++ empty_Format)
+                 ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+                  format_list (format_nat 8) ◦ data)
+                 (EquivFormat_UnderSequence'
+                    ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                    (format_nat 8 ◦ Datatypes.length ∘ data)
+                    (format_list (format_nat 8) ◦ data)
+                    (format_list (format_nat 8) ◦ data ++ empty_Format)
+                    (EquivFormat_trans
+                       ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (EquivFormat_compose_map (format_nat 8) data
+                          Datatypes.length)
+                       (EquivFormat_reflexive
+                          (format_nat 8 ◦ Datatypes.length ∘ data)))
+                    (EquivFormat_Projection_Format_Empty_Format'
+                       (format_list (format_nat 8))
+                       (format_list (format_nat 8)) data data
+                       (EquivFormat_reflexive
+                          (format_list (format_nat 8) ◦ data))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list (format_nat 8) ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list (format_nat 8) ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/MissingLength.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant (format_list format_word ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_list format_word ◦ data ++ empty_Format)
+                 (format_list format_word ◦ data)
+                 (EquivFormat_Projection_Format_Empty_Format'
+                    (format_list format_word) (format_list format_word) data
+                    data
+                    (EquivFormat_reflexive (format_list format_word ◦ data)))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_list format_word ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_list format_word ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     (format_list format_word ◦ data ++
+      (format_nat 8 ◦ Datatypes.length) ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_list format_word ◦ data ++
+                  format_nat 8 ◦ Datatypes.length ∘ data ++ empty_Format)
+                 (format_list format_word ◦ data ++
+                  (format_nat 8 ◦ Datatypes.length) ◦ data)
+                 (EquivFormat_UnderSequence' (format_list format_word ◦ data)
+                    (format_list format_word ◦ data)
+                    ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                    (format_nat 8 ◦ Datatypes.length ∘ data ++ empty_Format)
+                    (EquivFormat_reflexive (format_list format_word ◦ data))
+                    (EquivFormat_Projection_Format_Empty_Format'
+                       (format_nat 8 ◦ Datatypes.length) 
+                       (format_nat 8) data (Datatypes.length ∘ data)
+                       (EquivFormat_compose_map (format_nat 8) data
+                          Datatypes.length)))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_list format_word ◦ data ++
+                        format_nat 8 ◦ Datatypes.length ∘ data ++
+                        empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_list format_word ◦ data ++
+                        format_nat 8 ◦ Datatypes.length ∘ data ++
+                        empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list format_word ◦ data)
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop))
+     (constant format_decode_correct_refineEquiv msg ByteString test_cache
+                 AlignedByteString.ByteStringQueueMonoid invariant
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (DecodeM (msg * ByteString) ByteString))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CacheDecode -> Prop))
+                 (format_nat 8 ◦ Datatypes.length ∘ data ++
+                  format_list format_word ◦ data ++ empty_Format)
+                 ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+                  format_list format_word ◦ data)
+                 (EquivFormat_UnderSequence'
+                    ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                    (format_nat 8 ◦ Datatypes.length ∘ data)
+                    (format_list format_word ◦ data)
+                    (format_list format_word ◦ data ++ empty_Format)
+                    (EquivFormat_trans
+                       ((format_nat 8 ◦ Datatypes.length) ◦ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (format_nat 8 ◦ Datatypes.length ∘ data)
+                       (EquivFormat_compose_map (format_nat 8) data
+                          Datatypes.length)
+                       (EquivFormat_reflexive
+                          (format_nat 8 ◦ Datatypes.length ∘ data)))
+                    (EquivFormat_Projection_Format_Empty_Format'
+                       (format_list format_word) (format_list format_word)
+                       data data
+                       (EquivFormat_reflexive
+                          (format_list format_word ◦ data))))
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (CorrectDecoder AlignedByteString.ByteStringQueueMonoid
+                       invariant invariant eq
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list format_word ◦ data ++ empty_Format)
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (DecodeM (msg * ByteString) ByteString))
+                       (failing_case
+                          (ErrorMessage "Unable to synthesize decoder.")
+                          (CacheDecode -> Prop))
+                       (format_nat 8 ◦ Datatypes.length ∘ data ++
+                        format_list format_word ◦ data ++ empty_Format))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop))))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := true in
+   let H2 := true in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list format_bool ◦ data)
+     (sequence_Decode (decode_nat 8)
+        (fun v1 : nat =>
+         sequence_Decode (decode_list decode_bool v1)
+           (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+            if (true && true && true)%bool
+            then Some ({| data := v0 |}, t', ctxD)
+            else None)))
+     (fun (b : ByteString) (cd : ()) =>
+      `(a, b0, env) <- decode_word b cd;
+      (fun (a0 : word 8) (b1 : ByteString) (d : ()) =>
+       `(a1, b2, env0) <- decode_list decode_bool (wordToNat a0) b1 d;
+       (fun (l : list bool) (b3 : ByteString) (u : ()) =>
+        Some ({| data := l |}, b3, u)) a1 b2 env0) a b0 env)
+     (fun numBytes : nat =>
+      b <- GetCurrentByte;
+      (fun (b0 : word 8) (numBytes0 : nat) =>
+       l <- ListAlignedDecodeM
+              (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                 (forall m : nat, AlignedDecodeM bool m)) 
+              (wordToNat b0);
+       (fun (b1 : list bool) (numBytes1 : nat) => return {| data := b1 |}) l
+         numBytes0) b numBytes) (constant True)
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      (fun P0 : CacheDecode -> Prop =>
+       (fun P1 : CacheDecode -> Prop =>
+        forall (b : nat) (cd : CacheDecode), P1 cd -> P1 (addD cd b)) P0 /\
+       (constant True) P0) P)
+     (fun
+        H3 : cache_inv_Property (constant True)
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                (fun P0 : CacheDecode -> Prop =>
+                 (fun P1 : CacheDecode -> Prop =>
+                  forall (b : nat) (cd : CacheDecode),
+                  P1 cd -> P1 (addD cd b)) P0 /\ (constant True) P0) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode (decode_nat 8)
+           (fun v1 : nat =>
+            sequence_Decode (decode_list decode_bool v1)
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if (true && true && true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None))) (constant True)
+        (format_nat 8 ◦ Datatypes.length ∘ data ++
+         format_list format_bool ◦ data ++ empty_Format)
+        ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+         format_list format_bool ◦ data)
+        (EquivFormat_UnderSequence'
+           ((format_nat 8 ◦ Datatypes.length) ◦ data)
+           (format_nat 8 ◦ Datatypes.length ∘ data)
+           (format_list format_bool ◦ data)
+           (format_list format_bool ◦ data ++ empty_Format)
+           (EquivFormat_trans ((format_nat 8 ◦ Datatypes.length) ◦ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (EquivFormat_compose_map (format_nat 8) data Datatypes.length)
+              (EquivFormat_reflexive (format_nat 8 ◦ Datatypes.length ∘ data)))
+           (EquivFormat_Projection_Format_Empty_Format'
+              (format_list format_bool) (format_list format_bool) data data
+              (EquivFormat_reflexive (format_list format_bool ◦ data))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           (Datatypes.length ∘ data) invariant (fun n : nat => n < pow2 8)
+           (format_nat 8) (format_list format_bool ◦ data ++ empty_Format)
+           (decode_nat 8)
+           (fun
+              H6 : cache_inv_Property (constant True)
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Nat_decode_correct 8 H6)
+           (fun (H6 : msg) (H7 : invariant H6) => H7)
+           (fun v1 : nat =>
+            sequence_Decode (decode_list decode_bool v1)
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if (true && true && true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None))
+           (fun (v1 : nat)
+              (H6 : cache_inv_Property (constant True)
+                      (fun P : CacheDecode -> Prop =>
+                       (fun P0 : CacheDecode -> Prop =>
+                        forall (b : nat) (cd : CacheDecode),
+                        P0 cd -> P0 (addD cd b)) P /\ 
+                       (constant True) P))
+              (H7 : (fun n : nat => n < pow2 8) v1) =>
+            let H8 := true in
+            let H9 := true in
+            format_sequence_correct H6
+              AlignedByteString.ByteStringQueueMonoid data
+              (fun s : msg =>
+               invariant s /\ IsProj (Datatypes.length ∘ data) v1 s)
+              (fun ls : list bool =>
+               (| ls |) = v1 /\
+               (forall x : bool, In x ls -> (constant True) x))
+              (format_list format_bool) empty_Format
+              (decode_list decode_bool v1)
+              (fun
+                 H10 : cache_inv_Property (constant True)
+                         (fun P : CacheDecode -> Prop =>
+                          forall (b : nat) (cd : CacheDecode),
+                          P cd -> P (addD cd b)) =>
+               FixList_decode_correct (constant True) format_bool decode_bool
+                 (constant True) (bool_decode_correct H10) v1)
+              (fun (H10 : msg)
+                 (H11 : invariant H10 /\
+                        IsProj (Datatypes.length ∘ data) v1 H10) =>
+               let H12 : invariant H10 := proj1 H11 in
+               let H13 : IsProj (Datatypes.length ∘ data) v1 H10 := 
+                 proj2 H11 in
+               let H14 : (Datatypes.length ∘ data) H10 = v1 := 
+                 IsProj_eq H13 in
+               eq_ind_r
+                 (fun n : nat =>
+                  n = v1 /\ (forall x : bool, In x (data H10) -> True))
+                 (let H15 : v1 < pow2 8 :=
+                    eq_ind (| data H10 |) (fun n : nat => n < pow2 8) H12 v1
+                      H14 in
+                  conj eq_refl (fun x : bool => constant I)) H14)
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if (true && true && true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None)
+              (fun v0 : list bool =>
+               constant (fun
+                           H11 : (fun ls : list bool =>
+                                  (| ls |) = v1 /\
+                                  (forall x : bool,
+                                   In x ls -> (constant True) x)) v0 =>
+                         CorrectDecoderEmpty test_cache ByteStringQueueMonoid
+                           (fun s : msg =>
+                            (invariant s /\
+                             IsProj (Datatypes.length ∘ data) v1 s) /\
+                            IsProj data v0 s) (constant True)
+                           {| data := v0 |} (true && true && true)
+                           (fun H12 : msg =>
+                            match
+                              H12 as m
+                              return
+                                ((invariant m /\
+                                  IsProj (fun x : msg => | data x |) v1 m) /\
+                                 IsProj data v0 m -> 
+                                 m = {| data := v0 |})
+                            with
+                            | {| data := data0 |} =>
+                                match H11 with
+                                | conj H13 _ =>
+                                    fun
+                                      H15 : (invariant {| data := data0 |} /\
+                                             IsProj
+                                               (fun x : msg => | data x |) v1
+                                               {| data := data0 |}) /\
+                                            IsProj data v0
+                                              {| data := data0 |} =>
+                                    let H16 :
+                                      invariant {| data := data0 |} /\
+                                      IsProj (fun x : msg => | data x |) v1
+                                        {| data := data0 |} := 
+                                      proj1 H15 in
+                                    let H17 :
+                                      IsProj data v0 {| data := data0 |} :=
+                                      proj2 H15 in
+                                    let H18 :
+                                      invariant {| data := data0 |} :=
+                                      proj1 H16 in
+                                    let H19 :
+                                      IsProj (fun x : msg => | data x |) v1
+                                        {| data := data0 |} := 
+                                      proj2 H16 in
+                                    let H20 :
+                                      data {| data := data0 |} = v0 :=
+                                      IsProj_eq H17 in
+                                    eq_ind_r
+                                      (fun data1 : list bool =>
+                                       {| data := data1 |} = {| data := v0 |})
+                                      (let H21 :
+                                         IsProj (fun x : msg => | data x |)
+                                           v1 {| data := v0 |} :=
+                                         eq_ind data0
+                                           (fun data1 : ... =>
+                                            IsProj (...) v1 {| ... |}) H19 v0
+                                           H20 in
+                                       let H22 : (| data ... |) < pow2 8 :=
+                                         eq_ind data0 
+                                           (fun ... => ... < ...) H18 v0 H20
+                                         in
+                                       let H23 : (...) {| ... |} = v1 :=
+                                         IsProj_eq H21 in
+                                       let H24 : v1 = v1 :=
+                                         eq_ind (...) (...) H13 v1 H23 in
+                                       eq_refl) H20
+                                end
+                            end)
+                           (and_ind
+                              (fun H12 : (| v0 |) = v1 =>
+                               constant eq_ind (| v0 |)
+                                          (fun v2 : nat =>
+                                           v2 < pow2 8 ->
+                                           decides 
+                                             (true && true && true)
+                                             ((invariant {| data := v0 |} /\
+                                               (Datatypes.length ∘ data)
+                                                 {| data := v0 |} = v2) /\
+                                              v0 = v0))
+                                          (fun H14 : (| v0 |) < pow2 8 =>
+                                           decides_and 
+                                             (true && true) true
+                                             (invariant {| data := v0 |} /\
+                                              (Datatypes.length ∘ data)
+                                                {| data := v0 |} = 
+                                              (| v0 |)) 
+                                             (v0 = v0)
+                                             (decides_and true true
+                                                (invariant {| data := v0 |})
+                                                ((Datatypes.length ∘ data)
+                                                 {| data := v0 |} = 
+                                                 (| v0 |))
+                                                (decides_assumption H14)
+                                                (decides_eq_refl (| v0 |)))
+                                             (decides_eq_refl v0)) v1 H12 H7)
+                              H11))))))
+     (unfold_cache_inv_Property test_cache (constant True)
+        (fun P : CacheDecode -> Prop =>
+         (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+         (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\ True)
+        (conj (constant (constant (constant I)))
+           (conj (constant (constant (constant I))) I)))
+     (fun (b : ByteString) (cd : ()) =>
+      eq_ind_r
+        (fun o : option (msg * ByteString * ()) =>
+         o =
+         (fun (b0 : ByteString) (cd0 : ()) =>
+          `(a, b1, env) <- decode_word b0 cd0;
+          (fun (a0 : word 8) (b2 : ByteString) (d : ()) =>
+           `(a1, b3, env0) <- decode_list decode_bool (wordToNat a0) b2 d;
+           (fun (l : list bool) (b4 : ByteString) (u : ()) =>
+            Some ({| data := l |}, b4, u)) a1 b3 env0) a b1 env) b cd)
+        (DecodeBindOpt2_under_bind' (word 8) ByteString msg CacheDecode
+           ByteString (decode_word b cd)
+           (fun (a : word 8) (b0 : ByteString) (env : CacheDecode) =>
+            `(s', t', env') <- decode_list decode_bool (wordToNat a) b0 env;
+            Some ({| data := s' |}, t', env'))
+           (fun (a : word 8) (b0 : ByteString) (d : ()) =>
+            `(a0, b1, env) <- decode_list decode_bool (wordToNat a) b0 d;
+            (fun (l : list bool) (b2 : ByteString) (u : ()) =>
+             Some ({| data := l |}, b2, u)) a0 b1 env)
+           (fun (a : word 8) (b0 : ByteString) (d : ()) =>
+            constant DecodeBindOpt2_under_bind' (list bool) ByteString msg
+                       CacheDecode ByteString
+                       (decode_list decode_bool (wordToNat a) b0 d)
+                       (fun (a0 : list bool) (b1 : ByteString)
+                          (env : CacheDecode) =>
+                        Some ({| data := a0 |}, b1, env))
+                       (fun (l : list bool) (b1 : ByteString) (u : ()) =>
+                        Some ({| data := l |}, b1, u))
+                       (fun (a0 : list bool) (b1 : ByteString) (d0 : ()) =>
+                        constant reflexivity
+                                   (Some ({| data := a0 |}, b1, d0)))))
+        (DecodeBindOpt2_assoc (decode_word b cd)
+           (fun (w : word 8) (b0 : ByteString) (cd0 : ()) =>
+            Some (wordToNat w, b0, cd0))
+           (fun (s' : nat) (t' : ByteString) (env' : ()) =>
+            `(s'0, t'0, env'0) <- decode_list decode_bool s' t' env';
+            Some ({| data := s'0 |}, t'0, env'0))))
+     (AlignedDecodeBindCharM
+        (fun (a : word 8) (b0 : ByteString) (cd' : CacheDecode) =>
+         `(a0, b, env) <- decode_list decode_bool (wordToNat a) b0 cd';
+         Some ({| data := a0 |}, b, env))
+        (fun (b : word 8) (numBytes : nat) =>
+         l <- ListAlignedDecodeM
+                (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                   (forall m : nat, AlignedDecodeM bool m)) 
+                (wordToNat b);
+         (fun (b0 : list bool) (numBytes0 : nat) => return {| data := b0 |})
+           l numBytes)
+        (fun b : word 8 =>
+         AlignedDecodeListM decode_bool
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall m : nat, AlignedDecodeM bool m)) 
+           (wordToNat b)
+           (fun (l : list bool) (bs : ByteString) (cd' : CacheDecode) =>
+            Some ({| data := l |}, bs, cd'))
+           (fun (b0 : list bool) (numBytes : nat) => return {| data := b0 |})
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeMEquivAlignedDecodeM decode_bool
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (forall m : nat, AlignedDecodeM bool m))))
+           (fun b0 : list bool =>
+            Return_DecodeMEquivAlignedDecodeM {| data := b0 |}))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := true in
+   let H2 := true in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list format_bool ◦ data)
+     (sequence_Decode (decode_nat 8)
+        (fun v1 : nat =>
+         sequence_Decode (decode_list decode_bool v1)
+           (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+            if
+             (true && ((| data {| data := v0 |} |) mod 8 =? 0) && true &&
+              true)%bool
+            then Some ({| data := v0 |}, t', ctxD)
+            else None)))
+     (fun (b : ByteString) (cd : ()) =>
+      `(a, b0, env) <- decode_word b cd;
+      (fun (a0 : word 8) (b1 : ByteString) (d : ()) =>
+       `(a1, b2, env0) <- decode_list decode_bool (wordToNat a0) b1 d;
+       (fun (a2 : list bool) (b3 : ByteString) (d0 : ()) =>
+        if
+         match snd (Nat.divmod (| a2 |) 7 0 7) with
+         | 0 => 7
+         | 1 => 6
+         | 2 => 5
+         | 3 => 4
+         | 4 => 3
+         | 5 => 2
+         | 6 => 1
+         | S (S (S (S (S (S (S _)))))) => 0
+         end =? 0
+        then Some ({| data := a2 |}, b3, d0)
+        else None) a1 b2 env0) a b0 env)
+     (fun numBytes : nat =>
+      b <- GetCurrentByte;
+      (fun (b0 : word 8) (numBytes0 : nat) =>
+       l <- ListAlignedDecodeM
+              (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                 (forall m : nat, AlignedDecodeM bool m)) 
+              (wordToNat b0);
+       (fun (b1 : list bool) (sz : nat) =>
+        if
+         match snd (Nat.divmod (| b1 |) 7 0 7) with
+         | 0 => 7
+         | 1 => 6
+         | 2 => 5
+         | 3 => 4
+         | 4 => 3
+         | 5 => 2
+         | 6 => 1
+         | S (S (S (S (S (S (S _)))))) => 0
+         end =? 0
+        then (fun numBytes1 : nat => return {| data := b1 |}) sz
+        else fail) l numBytes0) b numBytes) (constant True)
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      (fun P0 : CacheDecode -> Prop =>
+       (fun P1 : CacheDecode -> Prop =>
+        forall (b : nat) (cd : CacheDecode), P1 cd -> P1 (addD cd b)) P0 /\
+       (constant True) P0) P)
+     (fun
+        H3 : cache_inv_Property (constant True)
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                (fun P0 : CacheDecode -> Prop =>
+                 (fun P1 : CacheDecode -> Prop =>
+                  forall (b : nat) (cd : CacheDecode),
+                  P1 cd -> P1 (addD cd b)) P0 /\ (constant True) P0) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode (decode_nat 8)
+           (fun v1 : nat =>
+            sequence_Decode (decode_list decode_bool v1)
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if
+                (true && ((| data {| data := v0 |} |) mod 8 =? 0) && true &&
+                 true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None))) (constant True)
+        (format_nat 8 ◦ Datatypes.length ∘ data ++
+         format_list format_bool ◦ data ++ empty_Format)
+        ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+         format_list format_bool ◦ data)
+        (EquivFormat_UnderSequence'
+           ((format_nat 8 ◦ Datatypes.length) ◦ data)
+           (format_nat 8 ◦ Datatypes.length ∘ data)
+           (format_list format_bool ◦ data)
+           (format_list format_bool ◦ data ++ empty_Format)
+           (EquivFormat_trans ((format_nat 8 ◦ Datatypes.length) ◦ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (EquivFormat_compose_map (format_nat 8) data Datatypes.length)
+              (EquivFormat_reflexive (format_nat 8 ◦ Datatypes.length ∘ data)))
+           (EquivFormat_Projection_Format_Empty_Format'
+              (format_list format_bool) (format_list format_bool) data data
+              (EquivFormat_reflexive (format_list format_bool ◦ data))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           (Datatypes.length ∘ data) invariant (fun n : nat => n < pow2 8)
+           (format_nat 8) (format_list format_bool ◦ data ++ empty_Format)
+           (decode_nat 8)
+           (fun
+              H6 : cache_inv_Property (constant True)
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Nat_decode_correct 8 H6)
+           (fun (H6 : msg) (H7 : invariant H6) =>
+            let H8 : (| data H6 |) < pow2 8 := proj1 H7 in
+            let H9 : (| data H6 |) mod 8 = 0 := proj2 H7 in H8)
+           (fun v1 : nat =>
+            sequence_Decode (decode_list decode_bool v1)
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if
+                (true && ((| data {| data := v0 |} |) mod 8 =? 0) && true &&
+                 true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None))
+           (fun (v1 : nat)
+              (H6 : cache_inv_Property (constant True)
+                      (fun P : CacheDecode -> Prop =>
+                       (fun P0 : CacheDecode -> Prop =>
+                        forall (b : nat) (cd : CacheDecode),
+                        P0 cd -> P0 (addD cd b)) P /\ 
+                       (constant True) P))
+              (H7 : (fun n : nat => n < pow2 8) v1) =>
+            let H8 := true in
+            let H9 := true in
+            format_sequence_correct H6
+              AlignedByteString.ByteStringQueueMonoid data
+              (fun s : msg =>
+               invariant s /\ IsProj (Datatypes.length ∘ data) v1 s)
+              (fun ls : list bool =>
+               (| ls |) = v1 /\
+               (forall x : bool, In x ls -> (constant True) x))
+              (format_list format_bool) empty_Format
+              (decode_list decode_bool v1)
+              (fun
+                 H10 : cache_inv_Property (constant True)
+                         (fun P : CacheDecode -> Prop =>
+                          forall (b : nat) (cd : CacheDecode),
+                          P cd -> P (addD cd b)) =>
+               FixList_decode_correct (constant True) format_bool decode_bool
+                 (constant True) (bool_decode_correct H10) v1)
+              (fun (H10 : msg)
+                 (H11 : invariant H10 /\
+                        IsProj (Datatypes.length ∘ data) v1 H10) =>
+               let H12 : invariant H10 := proj1 H11 in
+               let H13 : IsProj (Datatypes.length ∘ data) v1 H10 := 
+                 proj2 H11 in
+               let H14 : (| data H10 |) < pow2 8 := proj1 H12 in
+               let H15 : (| data H10 |) mod 8 = 0 := proj2 H12 in
+               let H16 : (Datatypes.length ∘ data) H10 = v1 := 
+                 IsProj_eq H13 in
+               let H17 :
+                 match snd (Nat.divmod v1 7 0 7) with
+                 | 0 => 7
+                 | 1 => 6
+                 | 2 => 5
+                 | 3 => 4
+                 | 4 => 3
+                 | 5 => 2
+                 | 6 => 1
+                 | S (S (S (S (S (S (S _)))))) => 0
+                 end = 0 :=
+                 eq_ind (| data H10 |)
+                   (fun n : nat =>
+                    match snd (Nat.divmod n 7 0 7) with
+                    | 0 => 7
+                    | 1 => 6
+                    | 2 => 5
+                    | 3 => 4
+                    | 4 => 3
+                    | 5 => 2
+                    | 6 => 1
+                    | S (S (S (S (S (S (S _)))))) => 0
+                    end = 0) H15 v1 H16 in
+               let H18 : v1 < pow2 8 :=
+                 eq_ind (| data H10 |) (fun n : nat => n < pow2 8) H14 v1 H16
+                 in
+               conj H16 (fun x : bool => constant I))
+              (fun (v0 : list bool) (t' : ByteString) (ctxD : CacheDecode) =>
+               if
+                (true && ((| data {| data := v0 |} |) mod 8 =? 0) && true &&
+                 true)%bool
+               then Some ({| data := v0 |}, t', ctxD)
+               else None)
+              (fun v0 : list bool =>
+               constant (fun
+                           H11 : (fun ls : list bool =>
+                                  (| ls |) = v1 /\
+                                  (forall x : bool,
+                                   In x ls -> (constant True) x)) v0 =>
+                         CorrectDecoderEmpty test_cache ByteStringQueueMonoid
+                           (fun s : msg =>
+                            (invariant s /\
+                             IsProj (Datatypes.length ∘ data) v1 s) /\
+                            IsProj data v0 s) (constant True)
+                           {| data := v0 |}
+                           (true && ((| data {| data := v0 |} |) mod 8 =? 0) &&
+                            true && true)
+                           (fun H12 : msg =>
+                            match
+                              H12 as m
+                              return
+                                ((invariant m /\
+                                  IsProj (fun x : msg => | data x |) v1 m) /\
+                                 IsProj data v0 m -> 
+                                 m = {| data := v0 |})
+                            with
+                            | {| data := data0 |} =>
+                                match H11 with
+                                | conj _ _ =>
+                                    fun
+                                      H15 : (invariant {| data := data0 |} /\
+                                             IsProj
+                                               (fun x : msg => | data x |) v1
+                                               {| data := data0 |}) /\
+                                            IsProj data v0
+                                              {| data := data0 |} =>
+                                    let H16 :
+                                      invariant {| data := data0 |} /\
+                                      IsProj (fun x : msg => | data x |) v1
+                                        {| data := data0 |} := 
+                                      proj1 H15 in
+                                    let H17 :
+                                      IsProj data v0 {| data := data0 |} :=
+                                      proj2 H15 in
+                                    let H18 :
+                                      invariant {| data := data0 |} :=
+                                      proj1 H16 in
+                                    let H19 :
+                                      IsProj (fun x : msg => | data x |) v1
+                                        {| data := data0 |} := 
+                                      proj2 H16 in
+                                    let H20 :
+                                      (| data {| data := data0 |} |) < pow2 8 :=
+                                      proj1 H18 in
+                                    let H21 :
+                                      (| data {| ... |} |) mod 8 = 0 :=
+                                      proj2 H18 in
+                                    let H22 :
+                                      (fun x : msg => | data x |)
+                                        {| data := data0 |} = v1 :=
+                                      IsProj_eq H19 in
+                                    let H23 :
+                                      match ... with
+                                      | 0 => 7
+                                      | 1 => 6
+                                      | 2 => 5
+                                      | 3 => 4
+                                      | 4 => 3
+                                      | 5 => 2
+                                      | 6 => 1
+                                      | S ... => 0
+                                      end = 0 :=
+                                      eq_ind (| data0 |)
+                                        (fun n : nat =>
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         ...
+                                         end = 0) H21 v1 H22 in
+                                    let H24 : v1 < pow2 8 :=
+                                      eq_ind (| data0 |) 
+                                        (fun ... => n < ...) H20 v1 H22 in
+                                    let H25 : data {| ... |} = v0 :=
+                                      IsProj_eq H17 in
+                                    eq_ind_r (fun ... => ... = ...)
+                                      (let H26 : ... := ... in eq_refl) H25
+                                end
+                            end)
+                           (and_ind
+                              (fun H12 : (| v0 |) = v1 =>
+                               constant eq_ind (| v0 |)
+                                          (fun v2 : nat =>
+                                           v2 < pow2 8 ->
+                                           decides
+                                             (true &&
+                                              ((| data {| ... |} |) mod 8 =?
+                                               0) && true && true)
+                                             ((invariant {| data := v0 |} /\
+                                               (Datatypes.length ∘ data)
+                                                 {| data := v0 |} = v2) /\
+                                              v0 = v0))
+                                          (fun H14 : (| v0 |) < pow2 8 =>
+                                           decides_and
+                                             (true &&
+                                              ((| data {| data := v0 |} |)
+                                               mod 8 =? 0) && true) true
+                                             (invariant {| data := v0 |} /\
+                                              (Datatypes.length ∘ data)
+                                                {| data := v0 |} = 
+                                              (| v0 |)) 
+                                             (v0 = v0)
+                                             (decides_and
+                                                (true &&
+                                                 ((| data {| data := v0 |} |)
+                                                 mod 8 =? 0)) true
+                                                (invariant {| data := v0 |})
+                                                ((Datatypes.length ∘ data)
+                                                 {| data := v0 |} = 
+                                                 (| v0 |))
+                                                (decides_and true
+                                                 ((| data {| data := v0 |} |)
+                                                 mod 8 =? 0)
+                                                 ((| data {| data := v0 |} |) <
+                                                 pow2 8)
+                                                 ((| data {| data := v0 |} |)
+                                                 mod 8 = 0)
+                                                 (decides_assumption H14)
+                                                 (decides_nat_eq
+                                                 ((| data {| ... |} |) mod 8)
+                                                 0))
+                                                (decides_eq_refl (| v0 |)))
+                                             (decides_eq_refl v0)) v1 H12 H7)
+                              H11))))))
+     (unfold_cache_inv_Property test_cache (constant True)
+        (fun P : CacheDecode -> Prop =>
+         (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+         (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\ True)
+        (conj (constant (constant (constant I)))
+           (conj (constant (constant (constant I))) I)))
+     (fun (b : ByteString) (cd : ()) =>
+      eq_ind_r
+        (fun o : option (msg * ByteString * ()) =>
+         o =
+         (fun (b0 : ByteString) (cd0 : ()) =>
+          `(a, b1, env) <- decode_word b0 cd0;
+          (fun (a0 : word 8) (b2 : ByteString) (d : ()) =>
+           `(a1, b3, env0) <- decode_list decode_bool (wordToNat a0) b2 d;
+           (fun (a2 : list bool) (b4 : ByteString) (d0 : ()) =>
+            if
+             match snd (Nat.divmod (| a2 |) 7 0 7) with
+             | 0 => 7
+             | 1 => 6
+             | 2 => 5
+             | 3 => 4
+             | 4 => 3
+             | 5 => 2
+             | 6 => 1
+             | S (S (S (S (S (S (S _)))))) => 0
+             end =? 0
+            then Some ({| data := a2 |}, b4, d0)
+            else None) a1 b3 env0) a b1 env) b cd)
+        (DecodeBindOpt2_under_bind' (word 8) ByteString msg CacheDecode
+           ByteString (decode_word b cd)
+           (fun (a : word 8) (b0 : ByteString) (env : CacheDecode) =>
+            `(s', t', env') <- decode_list decode_bool (wordToNat a) b0 env;
+            (if
+              (true &&
+               (match snd (Nat.divmod (| s' |) 7 0 7) with
+                | 0 => 7
+                | 1 => 6
+                | 2 => 5
+                | 3 => 4
+                | 4 => 3
+                | 5 => 2
+                | 6 => 1
+                | S (S (S (S (S (S (S _)))))) => 0
+                end =? 0) && true && true)%bool
+             then Some ({| data := s' |}, t', env')
+             else None))
+           (fun (a : word 8) (b0 : ByteString) (d : ()) =>
+            `(a0, b1, env) <- decode_list decode_bool (wordToNat a) b0 d;
+            (fun (a1 : list bool) (b2 : ByteString) (d0 : ()) =>
+             if
+              match snd (Nat.divmod (| a1 |) 7 0 7) with
+              | 0 => 7
+              | 1 => 6
+              | 2 => 5
+              | 3 => 4
+              | 4 => 3
+              | 5 => 2
+              | 6 => 1
+              | S (S (S (S (S (S (S _)))))) => 0
+              end =? 0
+             then Some ({| data := a1 |}, b2, d0)
+             else None) a0 b1 env)
+           (fun (a : word 8) (b0 : ByteString) (d : ()) =>
+            constant DecodeBindOpt2_under_bind' (list bool) ByteString msg
+                       CacheDecode ByteString
+                       (decode_list decode_bool (wordToNat a) b0 d)
+                       (fun (a0 : list bool) (b1 : ByteString)
+                          (env : CacheDecode) =>
+                        if
+                         (true &&
+                          (match snd (Nat.divmod (| a0 |) 7 0 7) with
+                           | 0 => 7
+                           | 1 => 6
+                           | 2 => 5
+                           | 3 => 4
+                           | 4 => 3
+                           | 5 => 2
+                           | 6 => 1
+                           | S (S (S (S (S (S (S _)))))) => 0
+                           end =? 0) && true && true)%bool
+                        then Some ({| data := a0 |}, b1, env)
+                        else None)
+                       (fun (a0 : list bool) (b1 : ByteString) (d0 : ()) =>
+                        if
+                         match snd (Nat.divmod (| a0 |) 7 0 7) with
+                         | 0 => 7
+                         | 1 => 6
+                         | 2 => 5
+                         | 3 => 4
+                         | 4 => 3
+                         | 5 => 2
+                         | 6 => 1
+                         | S (S (S (S (S (S (S _)))))) => 0
+                         end =? 0
+                        then Some ({| data := a0 |}, b1, d0)
+                        else None)
+                       (fun (a0 : list bool) (b1 : ByteString) (d0 : ()) =>
+                        constant eq_ind_r
+                                   (fun b2 : bool =>
+                                    (if b2
+                                     then Some ({| data := a0 |}, b1, d0)
+                                     else None) =
+                                    (fun (a1 : list bool) 
+                                       (b3 : ByteString) 
+                                       (d1 : ()) =>
+                                     if
+                                      match
+                                        snd (Nat.divmod (| a1 |) 7 0 7)
+                                      with
+                                      | 0 => 7
+                                      | 1 => 6
+                                      | 2 => 5
+                                      | 3 => 4
+                                      | 4 => 3
+                                      | 5 => 2
+                                      | 6 => 1
+                                      | S (S (S (S (S (S (S _)))))) => 0
+                                      end =? 0
+                                     then Some ({| data := a1 |}, b3, d1)
+                                     else None) a0 b1 d0)
+                                   (eq_ind_r
+                                      (fun b2 : bool =>
+                                       (if b2
+                                        then Some ({| data := a0 |}, b1, d0)
+                                        else None) =
+                                       (fun (a1 : list bool)
+                                          (b3 : ByteString) 
+                                          (d1 : ()) =>
+                                        if
+                                         match
+                                           snd (Nat.divmod (| a1 |) 7 0 7)
+                                         with
+                                         | 0 => 7
+                                         | 1 => 6
+                                         | 2 => 5
+                                         | 3 => 4
+                                         | 4 => 3
+                                         | 5 => 2
+                                         | 6 => 1
+                                         | S (S (S (S (S (S (S _)))))) => 0
+                                         end =? 0
+                                        then Some ({| data := a1 |}, b3, d1)
+                                        else None) a0 b1 d0)
+                                      (eq_ind_r
+                                         (fun b2 : bool =>
+                                          (if b2
+                                           then
+                                            Some ({| data := a0 |}, b1, d0)
+                                           else None) =
+                                          (fun (a1 : list bool)
+                                             (b3 : ByteString) 
+                                             (d1 : ()) =>
+                                           if
+                                            match
+                                              snd (Nat.divmod (| a1 |) 7 0 7)
+                                            with
+                                            | 0 => 7
+                                            | 1 => 6
+                                            | 2 => 5
+                                            | 3 => 4
+                                            | 4 => 3
+                                            | 5 => 2
+                                            | 6 => 1
+                                            | S (S (S (S (S (S (S _)))))) =>
+                                                0
+                                            end =? 0
+                                           then
+                                            Some ({| data := a1 |}, b3, d1)
+                                           else None) a0 b1 d0)
+                                         (optimize_under_if_bool
+                                            (match
+                                               snd
+                                                 (Nat.divmod (| a0 |) 7 0 7)
+                                             with
+                                             | 0 => 7
+                                             | 1 => 6
+                                             | 2 => 5
+                                             | 3 => 4
+                                             | 4 => 3
+                                             | 5 => 2
+                                             | 6 => 1
+                                             | S (S (S (S (S (S (S _)))))) =>
+                                                 0
+                                             end =? 0)
+                                            (Some ({| data := a0 |}, b1, d0))
+                                            (Some ({| data := a0 |}, b1, d0))
+                                            None None eq_refl eq_refl)
+                                         (Bool.andb_true_l
+                                            (match
+                                               snd
+                                                 (Nat.divmod (| a0 |) 7 0 7)
+                                             with
+                                             | 0 => 7
+                                             | 1 => 6
+                                             | 2 => 5
+                                             | 3 => 4
+                                             | 4 => 3
+                                             | 5 => 2
+                                             | 6 => 1
+                                             | S (S (S (S (S (S (S _)))))) =>
+                                                 0
+                                             end =? 0)))
+                                      (Bool.andb_true_r
+                                         (true &&
+                                          (match
+                                             snd (Nat.divmod (| a0 |) 7 0 7)
+                                           with
+                                           | 0 => 7
+                                           | 1 => 6
+                                           | 2 => 5
+                                           | 3 => 4
+                                           | 4 => 3
+                                           | 5 => 2
+                                           | 6 => 1
+                                           | S (S (S (S (S (S (S _)))))) => 0
+                                           end =? 0))))
+                                   (Bool.andb_true_r
+                                      (true &&
+                                       (match
+                                          snd (Nat.divmod (| a0 |) 7 0 7)
+                                        with
+                                        | 0 => 7
+                                        | 1 => 6
+                                        | 2 => 5
+                                        | 3 => 4
+                                        | 4 => 3
+                                        | 5 => 2
+                                        | 6 => 1
+                                        | S (S (S (S (S (S (S _)))))) => 0
+                                        end =? 0) && true)))))
+        (DecodeBindOpt2_assoc (decode_word b cd)
+           (fun (w : word 8) (b0 : ByteString) (cd0 : ()) =>
+            Some (wordToNat w, b0, cd0))
+           (fun (s' : nat) (t' : ByteString) (env' : ()) =>
+            `(s'0, t'0, env'0) <- decode_list decode_bool s' t' env';
+            (if
+              (true &&
+               (match snd (Nat.divmod (| s'0 |) 7 0 7) with
+                | 0 => 7
+                | 1 => 6
+                | 2 => 5
+                | 3 => 4
+                | 4 => 3
+                | 5 => 2
+                | 6 => 1
+                | S (S (S (S (S (S (S _)))))) => 0
+                end =? 0) && true && true)%bool
+             then Some ({| data := s'0 |}, t'0, env'0)
+             else None))))
+     (AlignedDecodeBindCharM
+        (fun (a : word 8) (b0 : ByteString) (cd' : CacheDecode) =>
+         `(a0, b, env) <- decode_list decode_bool (wordToNat a) b0 cd';
+         (if
+           match snd (Nat.divmod (| a0 |) 7 0 7) with
+           | 0 => 7
+           | 1 => 6
+           | 2 => 5
+           | 3 => 4
+           | 4 => 3
+           | 5 => 2
+           | 6 => 1
+           | S (S (S (S (S (S (S _)))))) => 0
+           end =? 0
+          then Some ({| data := a0 |}, b, env)
+          else None))
+        (fun (b : word 8) (numBytes : nat) =>
+         l <- ListAlignedDecodeM
+                (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                   (forall m : nat, AlignedDecodeM bool m)) 
+                (wordToNat b);
+         (fun (b0 : list bool) (sz : nat) =>
+          if
+           match snd (Nat.divmod (| b0 |) 7 0 7) with
+           | 0 => 7
+           | 1 => 6
+           | 2 => 5
+           | 3 => 4
+           | 4 => 3
+           | 5 => 2
+           | 6 => 1
+           | S (S (S (S (S (S (S _)))))) => 0
+           end =? 0
+          then (fun numBytes0 : nat => return {| data := b0 |}) sz
+          else fail) l numBytes)
+        (fun b : word 8 =>
+         AlignedDecodeListM decode_bool
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall m : nat, AlignedDecodeM bool m)) 
+           (wordToNat b)
+           (fun (l : list bool) (bs : ByteString) (cd' : CacheDecode) =>
+            if
+             match snd (Nat.divmod (| l |) 7 0 7) with
+             | 0 => 7
+             | 1 => 6
+             | 2 => 5
+             | 3 => 4
+             | 4 => 3
+             | 5 => 2
+             | 6 => 1
+             | S (S (S (S (S (S (S _)))))) => 0
+             end =? 0
+            then Some ({| data := l |}, bs, cd')
+            else None)
+           (fun (b0 : list bool) (sz : nat) =>
+            if
+             match snd (Nat.divmod (| b0 |) 7 0 7) with
+             | 0 => 7
+             | 1 => 6
+             | 2 => 5
+             | 3 => 4
+             | 4 => 3
+             | 5 => 2
+             | 6 => 1
+             | S (S (S (S (S (S (S _)))))) => 0
+             end =? 0
+            then (fun numBytes : nat => return {| data := b0 |}) sz
+            else fail)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeMEquivAlignedDecodeM decode_bool
+                 (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                    (forall m : nat, AlignedDecodeM bool m))))
+           (fun b0 : list bool =>
+            AlignedDecode_ifb
+              (fun (bs : ByteString) (cd : CacheDecode) =>
+               Some ({| data := b0 |}, bs, cd))
+              (match snd (Nat.divmod (| b0 |) 7 0 7) with
+               | 0 => 7
+               | 1 => 6
+               | 2 => 5
+               | 3 => 4
+               | 4 => 3
+               | 5 => 2
+               | 6 => 1
+               | S (S (S (S (S (S (S _)))))) => 0
+               end =? 0) (fun numBytes : nat => return {| data := b0 |})
+              (Return_DecodeMEquivAlignedDecodeM {| data := b0 |})))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/NestedList.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list
+        (format_nat 8 ◦ Datatypes.length ++ format_list format_word) ◦ data)
+     (sequence_Decode (decode_nat 8)
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (nat -> DecodeM (msg * ByteString) ByteString)))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop) P)
+     (fun
+        H3 : cache_inv_Property
+               (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  (CacheDecode -> Prop))
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  ((CacheDecode -> Prop) -> Prop) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode (decode_nat 8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString)))
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (CacheDecode -> Prop))
+        (format_nat 8 ◦ Datatypes.length ∘ data ++
+         format_list
+           (format_nat 8 ◦ Datatypes.length ++ format_list format_word)
+         ◦ data ++ empty_Format)
+        ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+         format_list
+           (format_nat 8 ◦ Datatypes.length ++ format_list format_word)
+         ◦ data)
+        (EquivFormat_UnderSequence'
+           ((format_nat 8 ◦ Datatypes.length) ◦ data)
+           (format_nat 8 ◦ Datatypes.length ∘ data)
+           (format_list
+              (format_nat 8 ◦ Datatypes.length ++ format_list format_word)
+            ◦ data)
+           (format_list
+              (format_nat 8 ◦ Datatypes.length ++ format_list format_word)
+            ◦ data ++ empty_Format)
+           (EquivFormat_trans ((format_nat 8 ◦ Datatypes.length) ◦ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (EquivFormat_compose_map (format_nat 8) data Datatypes.length)
+              (EquivFormat_reflexive (format_nat 8 ◦ Datatypes.length ∘ data)))
+           (EquivFormat_Projection_Format_Empty_Format'
+              (format_list
+                 (format_nat 8 ◦ Datatypes.length ++ format_list format_word))
+              (format_list
+                 (format_nat 8 ◦ Datatypes.length ++ format_list format_word))
+              data data
+              (EquivFormat_reflexive
+                 (format_list
+                    (format_nat 8 ◦ Datatypes.length ++
+                     format_list format_word) ◦ data))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           (Datatypes.length ∘ data) invariant (fun n : nat => n < pow2 8)
+           (format_nat 8)
+           (format_list
+              (format_nat 8 ◦ Datatypes.length ++ format_list format_word)
+            ◦ data ++ empty_Format) (decode_nat 8)
+           (fun
+              H6 : cache_inv_Property
+                     (failing_case
+                        (ErrorMessage "Unable to synthesize decoder.")
+                        (CacheDecode -> Prop))
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Nat_decode_correct 8 H6)
+           (fun (H6 : msg) (H7 : invariant H6) =>
+            let H8 : (| data H6 |) < pow2 8 := proj1 H7 in
+            let H9 :
+              forall l : list (word 8), In l (data H6) -> (| l |) < pow2 8 :=
+              proj2 H7 in
+            H8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString))
+           (fun v1 : nat =>
+            constant (constant failing_case
+                                 (ErrorMessage
+                                    "Unable to synthesize decoder.")
+                                 (CorrectDecoder
+                                    AlignedByteString.ByteStringQueueMonoid
+                                    (fun s : msg =>
+                                     invariant s /\
+                                     IsProj (Datatypes.length ∘ data) v1 s)
+                                    (fun s : msg =>
+                                     invariant s /\
+                                     IsProj (Datatypes.length ∘ data) v1 s)
+                                    eq
+                                    (format_list
+                                       (format_nat 8 ◦ Datatypes.length ++
+                                        format_list format_word) ◦ data ++
+                                     empty_Format)
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (nat ->
+                                        DecodeM (msg * ByteString) ByteString)
+                                       v1)
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (CacheDecode -> Prop))
+                                    (format_list
+                                       (format_nat 8 ◦ Datatypes.length ++
+                                        format_list format_word) ◦ data ++
+                                     empty_Format))))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (fun P : CacheDecode -> Prop =>
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop) P)))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (sequence_Decode (decode_nat 8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString)) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
+---------------------------------------------
+(let H := "Unable to synthesize decoder." in
+ let e := ErrorMessage "Unable to synthesize decoder." in
+ let H0 :=
+   let H0 := true in
+   let H1 := false in
+   let H2 := false in
+   Start_CorrectAlignedDecoderFor invariant
+     ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+      format_list (format_nat 8) ◦ data)
+     (sequence_Decode (decode_nat 8)
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (nat -> DecodeM (msg * ByteString) ByteString)))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeM (msg * ByteString) ByteString))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (forall sz : nat, AlignedDecodeM msg sz))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (CacheDecode -> Prop))
+     (fun P : CacheDecode -> Prop =>
+      (fun P0 : CacheDecode -> Prop =>
+       forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b)) P /\
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        ((CacheDecode -> Prop) -> Prop) P)
+     (fun
+        H3 : cache_inv_Property
+               (failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  (CacheDecode -> Prop))
+               (fun P : CacheDecode -> Prop =>
+                (fun P0 : CacheDecode -> Prop =>
+                 forall (b : nat) (cd : CacheDecode), P0 cd -> P0 (addD cd b))
+                  P /\
+                failing_case (ErrorMessage "Unable to synthesize decoder.")
+                  ((CacheDecode -> Prop) -> Prop) P) =>
+      format_decode_correct_refineEquiv msg ByteString test_cache
+        AlignedByteString.ByteStringQueueMonoid invariant
+        (sequence_Decode (decode_nat 8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString)))
+        (failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (CacheDecode -> Prop))
+        (format_nat 8 ◦ Datatypes.length ∘ data ++
+         format_list (format_nat 8) ◦ data ++ empty_Format)
+        ((format_nat 8 ◦ Datatypes.length) ◦ data ++
+         format_list (format_nat 8) ◦ data)
+        (EquivFormat_UnderSequence'
+           ((format_nat 8 ◦ Datatypes.length) ◦ data)
+           (format_nat 8 ◦ Datatypes.length ∘ data)
+           (format_list (format_nat 8) ◦ data)
+           (format_list (format_nat 8) ◦ data ++ empty_Format)
+           (EquivFormat_trans ((format_nat 8 ◦ Datatypes.length) ◦ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (format_nat 8 ◦ Datatypes.length ∘ data)
+              (EquivFormat_compose_map (format_nat 8) data Datatypes.length)
+              (EquivFormat_reflexive (format_nat 8 ◦ Datatypes.length ∘ data)))
+           (EquivFormat_Projection_Format_Empty_Format'
+              (format_list (format_nat 8)) (format_list (format_nat 8)) data
+              data
+              (EquivFormat_reflexive (format_list (format_nat 8) ◦ data))))
+        (let H4 := true in
+         let H5 := true in
+         format_sequence_correct H3 AlignedByteString.ByteStringQueueMonoid
+           (Datatypes.length ∘ data) invariant (fun n : nat => n < pow2 8)
+           (format_nat 8) (format_list (format_nat 8) ◦ data ++ empty_Format)
+           (decode_nat 8)
+           (fun
+              H6 : cache_inv_Property
+                     (failing_case
+                        (ErrorMessage "Unable to synthesize decoder.")
+                        (CacheDecode -> Prop))
+                     (fun P : CacheDecode -> Prop =>
+                      forall (b : nat) (cd : CacheDecode),
+                      P cd -> P (addD cd b)) => Nat_decode_correct 8 H6)
+           (fun (H6 : msg) (H7 : invariant H6) =>
+            let H8 : (| data H6 |) < pow2 8 := proj1 H7 in
+            let H9 : forall n : nat, In n (data H6) -> n < pow2 9 := 
+              proj2 H7 in
+            H8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString))
+           (fun v1 : nat =>
+            constant (constant failing_case
+                                 (ErrorMessage
+                                    "Unable to synthesize decoder.")
+                                 (CorrectDecoder
+                                    AlignedByteString.ByteStringQueueMonoid
+                                    (fun s : msg =>
+                                     invariant s /\
+                                     IsProj (Datatypes.length ∘ data) v1 s)
+                                    (fun s : msg =>
+                                     invariant s /\
+                                     IsProj (Datatypes.length ∘ data) v1 s)
+                                    eq
+                                    (format_list (format_nat 8) ◦ data ++
+                                     empty_Format)
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (nat ->
+                                        DecodeM (msg * ByteString) ByteString)
+                                       v1)
+                                    (failing_case
+                                       (ErrorMessage
+                                          "Unable to synthesize decoder.")
+                                       (CacheDecode -> Prop))
+                                    (format_list (format_nat 8) ◦ data ++
+                                     empty_Format))))))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (cache_inv_Property
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (CacheDecode -> Prop))
+           (fun P : CacheDecode -> Prop =>
+            (forall (b : nat) (cd : CacheDecode), P cd -> P (addD cd b)) /\
+            failing_case (ErrorMessage "Unable to synthesize decoder.")
+              ((CacheDecode -> Prop) -> Prop) P)))
+     (fun (b : ByteString) (cd : ()) =>
+      failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (sequence_Decode (decode_nat 8)
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (nat -> DecodeM (msg * ByteString) ByteString)) b cd =
+         failing_case (ErrorMessage "Unable to synthesize decoder.")
+           (DecodeM (msg * ByteString) ByteString) b cd))
+     (failing_case (ErrorMessage "Unable to synthesize decoder.")
+        (DecodeMEquivAlignedDecodeM
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (DecodeM (msg * ByteString) ByteString))
+           (failing_case (ErrorMessage "Unable to synthesize decoder.")
+              (forall sz : nat, AlignedDecodeM msg sz)))) in
+ Failure "Unable to synthesize decoder.")
+
+./src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v", line 15, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.

--- a/src/Narcissus/Examples/Errors/2022-06-02-error-report.txt
+++ b/src/Narcissus/Examples/Errors/2022-06-02-error-report.txt
@@ -1,0 +1,194 @@
+--------------------------------------------
+-- Narcissus Error Examples Output Report --
+--------------------------------------------
+
+./src/Narcissus/Examples/Errors/General/PointedComposition.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/General/PointedComposition.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/General/WrongCircle.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/General/WrongCircle.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v", line 10, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.
+
+./src/Narcissus/Examples/Errors/FormatWord/Endian.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatWord/Endian.v", line 16, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v", line 10, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.
+
+./src/Narcissus/Examples/Errors/FormatString/StringConst.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatString/StringConst.v", line 19, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/Record/NestedRecord.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/Record/NestedRecord.v", line 18, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/Record/FieldMissing.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/Record/FieldMissing.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v", line 15, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v", line 17, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/.#LengthAfterData.v
+---------------------------------------------
+Error:
+Can't find file
+./src/Narcissus/Examples/Errors/FormatList/.#LengthAfterData.v
+
+./src/Narcissus/Examples/Errors/FormatList/MissingLength.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/MissingLength.v", line 13, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v", line 15, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v", line 15, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v", line 15, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v", line 16, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/NestedList.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/NestedList.v", line 16, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v", line 16, characters 0-45:
+Warning: Interpreting this declaration as if a global declaration prefixed by
+"Local", i.e. as a global declaration which shall not be available without
+qualification when imported. [local-declaration,scope]
+dec' = "Unable to synthesize decoder."
+     : string
+Closed under the global context
+
+./src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
+---------------------------------------------
+File "./src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v", line 15, characters 2-34:
+Error: Tactic failure: [Proofview.tclTIMEOUT] Tactic timeout!.

--- a/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
@@ -1,10 +1,16 @@
-From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import
+        Fiat.Narcissus.Automation.AlignedAutomation
+        Fiat.Narcissus.Automation.Error
+        Fiat.Narcissus.Automation.Solver
+        Fiat.Narcissus.BaseFormats
+        Fiat.Narcissus.BinLib
+        Fiat.Narcissus.Common.Specs
+        Fiat.Narcissus.Formats.
 
 Record msg := { data : bool }.
 Definition format := format_bool ◦ data.
 Definition invariant (_ : msg) := True.
-
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
@@ -13,4 +13,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatBool/NotByteAligned.v
@@ -13,5 +13,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list bool }.
 Definition format :=
@@ -7,7 +8,7 @@ Definition format :=
 Definition invariant (m : msg) :=
   length (m.(data)) < pow2 8 /\ length (m.(data)) mod 8 = 0.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
@@ -11,5 +11,8 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/ActuallyByteAligned.v
@@ -11,4 +11,5 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
+++ b/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
@@ -10,5 +10,8 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
+++ b/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list (word 8) }.
 Definition format :=
@@ -6,7 +7,7 @@ Definition format :=
   format_nat 8 ◦ length ◦ data.
 Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
+++ b/src/Narcissus/Examples/Errors/FormatList/LengthAfterData.v
@@ -10,4 +10,5 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list (word 8) }.
 Definition format :=
@@ -6,7 +7,7 @@ Definition format :=
   format_list format_word ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
@@ -10,5 +10,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingInvariant.v
@@ -10,4 +10,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
+++ b/src/Narcissus/Examples/Errors/FormatList/MissingLength.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list (word 8) }.
 Definition format := format_list format_word ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list nat }.
 Definition format :=
@@ -8,7 +9,7 @@ Definition format :=
 Definition invariant (m : msg) :=
   forall n, In n m.(data) -> n < pow2 8 /\ length (m.(data)) < pow2 8.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
@@ -12,4 +12,5 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatNonStandardInvariant.v
@@ -12,5 +12,8 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
@@ -11,5 +11,8 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list nat }.
 Definition format :=
@@ -7,7 +8,7 @@ Definition format :=
 Definition invariant (m : msg) :=
   length (m.(data)) < pow2 8 /\ forall n, In n m.(data) -> n < pow2 9.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NatWrongInvariant.v
@@ -11,4 +11,5 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NestedList.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NestedList.v
@@ -11,5 +11,8 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/NestedList.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NestedList.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list (list (word 8)) }.
 Definition format :=
@@ -7,7 +8,7 @@ Definition format :=
 Definition invariant (m : msg) :=
   length (m.(data)) < pow2 8 /\ forall l, In l m.(data) -> length l < pow2 8.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NestedList.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NestedList.v
@@ -11,4 +11,5 @@ Definition invariant (m : msg) :=
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
@@ -10,5 +10,8 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
@@ -10,4 +10,5 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatList/NotByteAligned.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list bool }.
 Definition format :=
@@ -6,7 +7,7 @@ Definition format :=
   format_list format_bool ◦ data.
 Definition invariant (m : msg) := length (m.(data)) < pow2 8.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : list (word 8) }.
 Definition format :=
@@ -6,7 +7,7 @@ Definition format :=
   format_list format_word ◦ data.
 Definition invariant (m : msg) := length (m.(data)) < pow2 9.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
@@ -10,4 +10,5 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 9.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
+++ b/src/Narcissus/Examples/Errors/FormatList/WrongInvariant.v
@@ -10,5 +10,8 @@ Definition invariant (m : msg) := length (m.(data)) < pow2 9.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : bool }.
 Definition format := format_nat 7 ◦ const 0 ++ format_bool ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst1.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
+++ b/src/Narcissus/Examples/Errors/FormatNat/NonStandardConst2.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : bool }.
 Definition format := (fun _ => format_nat 7 0) ++ format_bool ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatString/StringConst.v
+++ b/src/Narcissus/Examples/Errors/FormatString/StringConst.v
@@ -11,6 +11,7 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
   (* More of a limitation than error: need to fix [solve_side_condition], add
   a decides instance, disallow simplifying the decoder function, and add a
   [DecodeMEquivAlignedDecodeM] instance. *)

--- a/src/Narcissus/Examples/Errors/FormatString/StringConst.v
+++ b/src/Narcissus/Examples/Errors/FormatString/StringConst.v
@@ -11,8 +11,11 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
   (* More of a limitation than error: need to fix [solve_side_condition], add
   a decides instance, disallow simplifying the decoder function, and add a
   [DecodeMEquivAlignedDecodeM] instance. *)
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatString/StringConst.v
+++ b/src/Narcissus/Examples/Errors/FormatString/StringConst.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 8 }.
 Definition format :=
@@ -7,9 +8,9 @@ Definition format :=
   format_string ◦ const "</data>".
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
   (* More of a limitation than error: need to fix [solve_side_condition], add
   a decides instance, disallow simplifying the decoder function, and add a
   [DecodeMEquivAlignedDecodeM] instance. *)

--- a/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 128 }.
 Definition format := format_word ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/BigWordHang.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatWord/Endian.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/Endian.v
@@ -11,5 +11,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatWord/Endian.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/Endian.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 16 }.
 (* How to achieve this? *)
@@ -7,7 +8,7 @@ Definition format :=
   format_word ◦ (split2 8 8 ∘ data).
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatWord/Endian.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/Endian.v
@@ -11,4 +11,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 1 }.
 Definition format := format_word ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
+++ b/src/Narcissus/Examples/Errors/FormatWord/NotByteAligned.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/General/PointedComposition.v
+++ b/src/Narcissus/Examples/Errors/General/PointedComposition.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/General/PointedComposition.v
+++ b/src/Narcissus/Examples/Errors/General/PointedComposition.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/General/PointedComposition.v
+++ b/src/Narcissus/Examples/Errors/General/PointedComposition.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 8 }.
 Definition format (m : msg) := format_word m.(data).
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/General/WrongCircle.v
+++ b/src/Narcissus/Examples/Errors/General/WrongCircle.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/General/WrongCircle.v
+++ b/src/Narcissus/Examples/Errors/General/WrongCircle.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 8 }.
 Definition format := format_word ∘ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/General/WrongCircle.v
+++ b/src/Narcissus/Examples/Errors/General/WrongCircle.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/Record/FieldMissing.v
+++ b/src/Narcissus/Examples/Errors/Record/FieldMissing.v
@@ -8,5 +8,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/Record/FieldMissing.v
+++ b/src/Narcissus/Examples/Errors/Record/FieldMissing.v
@@ -1,10 +1,11 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record msg := { data : word 8; tag : word 8 }.
 Definition format := format_word ◦ data.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/Record/FieldMissing.v
+++ b/src/Narcissus/Examples/Errors/Record/FieldMissing.v
@@ -8,4 +8,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/Record/NestedRecord.v
+++ b/src/Narcissus/Examples/Errors/Record/NestedRecord.v
@@ -1,4 +1,5 @@
 From Fiat.Narcissus Require Import Examples.TutorialPrelude.
+Require Import Fiat.Narcissus.Automation.Error.
 
 Record person := { age : word 8; salary : word 8 }.
 Record msg := { data : word 8; who : person }.
@@ -9,7 +10,7 @@ Definition format :=
   format_word ◦ salary ◦ who.
 Definition invariant (_ : msg) := True.
 
-Definition dec : CorrectAlignedDecoderFor invariant format.
+Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
-  synthesize_aligned_decoder.
+  maybe_synthesize_aligned_decoder.
 Defined.

--- a/src/Narcissus/Examples/Errors/Record/NestedRecord.v
+++ b/src/Narcissus/Examples/Errors/Record/NestedRecord.v
@@ -13,4 +13,5 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
+  Show Proof.
 Defined.

--- a/src/Narcissus/Examples/Errors/Record/NestedRecord.v
+++ b/src/Narcissus/Examples/Errors/Record/NestedRecord.v
@@ -13,5 +13,8 @@ Definition invariant (_ : msg) := True.
 Definition dec : Maybe (CorrectAlignedDecoderFor invariant format).
 Proof.
   maybe_synthesize_aligned_decoder.
-  Show Proof.
 Defined.
+
+Let dec' := Eval simpl in extractDecoder dec.
+Print dec'.
+Print Assumptions dec'.

--- a/src/Narcissus/Examples/Errors/run-error-report.sh
+++ b/src/Narcissus/Examples/Errors/run-error-report.sh
@@ -4,9 +4,9 @@
 # output into a report file.
 
 # Configuration.
-examples_dir="src/Narcissus/Examples/Errors"
+examples_dir="./src/Narcissus/Examples/Errors"
 coqc_args="-R src Fiat -R Bedrock Bedrock -I src/Common/Tactics"
-time_limit="10s"
+time_limit="60s"
 output_file="error-report.txt"
 
 # Write a header to the output file.


### PR DESCRIPTION
First pass at adding error reporting to decoder synthesis.

The meat of the change is in: [src/Narcissus/Automation/Error.v](https://github.com/bendy/fiat/blob/698807a7ae5812db9bad4c89988528532080a1fe/src/Narcissus/Automation/Error.v)
The results of this error reporting are in an updated error report: [src/Narcissus/Examples/Errors/2022-05-27-error-report.txt](https://github.com/bendy/fiat/blob/698807a7ae5812db9bad4c89988528532080a1fe/src/Narcissus/Examples/Errors/2022-05-27-error-report.txt)

Still outstanding is to ensure we are receiving appropriately specialized error messages; currently, most examples still yield an overly-generic "unable to synthesize decoder" message.